### PR TITLE
Always render system errors on exit regardless of fixer status

### DIFF
--- a/src/Console/Output/ConsoleOutputFormatter.php
+++ b/src/Console/Output/ConsoleOutputFormatter.php
@@ -103,6 +103,8 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
             return;
         }
 
+        $this->printSystemErrors($errorAndDiffResult);
+
         $this->printErrorMessageFromErrorCounts(
             $errorAndDiffResult->getCodingStandardErrorCount(),
             $errorAndDiffResult->getFileDiffsCount(),
@@ -120,6 +122,17 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
             }
         }
 
+        $this->printSystemErrors($errorAndDiffResult);
+
+        $this->printErrorMessageFromErrorCounts(
+            $errorAndDiffResult->getCodingStandardErrorCount(),
+            $errorAndDiffResult->getFileDiffsCount(),
+            $configuration
+        );
+    }
+
+    private function printSystemErrors(ErrorAndDiffResult $errorAndDiffResult): void
+    {
         $systemErrors = $errorAndDiffResult->getSystemErrors();
         foreach ($systemErrors as $systemError) {
             $this->easyCodingStandardStyle->newLine();
@@ -132,12 +145,6 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
                 $this->easyCodingStandardStyle->error($systemError);
             }
         }
-
-        $this->printErrorMessageFromErrorCounts(
-            $errorAndDiffResult->getCodingStandardErrorCount(),
-            $errorAndDiffResult->getFileDiffsCount(),
-            $configuration
-        );
     }
 
     private function printErrorMessageFromErrorCounts(


### PR DESCRIPTION
Previously, system errors were only rendered if running in `no fix` mode. When running with `--fix` then the ConsoleOutputFormatter only calls `printAfterFixerStatus()` and this did not display system errors.

This meant that the command could fail silently with a nonzero exit code (because the ExitCodeResolver exits 1 if there were any system errors, regardless of mode).

It looks like this was unintentional -
https://github.com/symplify/symplify/commit/d08859d3808f69d1b8502ece5d7a86a8077c5058 added the code to split system errors to a separate stream but only added code to render them in `printNoFixerStatus`

I think this is related to / masking some of the various caching bugs that have been reported previously e.g. #29 which mentions the process failing silently without any error message. In our case the system errors ECS encountered were also due to cache write failures.