### PR TITLE
Don't remove cache directories when invalidating cache items

### DIFF
--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -75,11 +75,7 @@ final class FileCacheStorage
     {
         $cacheFilePaths = $this->getCacheFilePaths($cacheKey);
 
-        $this->fileSystem->remove([
-            $cacheFilePaths->getFirstDirectory(),
-            $cacheFilePaths->getSecondDirectory(),
-            $cacheFilePaths->getFilePath(),
-        ]);
+        $this->fileSystem->remove($cacheFilePaths->getFilePath());
     }
 
     public function clear(): void


### PR DESCRIPTION
Cache items are stored under sharded directories - e.g. a file with key `73c6e8d18a37727bc4c360817516a1e367be1a4c` is stored at `{cache}/73/c6/73c6e8d18a37727bc4c360817516a1e367be1a4c`.

Previously, when removing an item, the cache would remove the parent directories as well as the item file. This caused two problems:

* Invalidating a single item unexpectedly removed the caches for *all* items that share the same first two characters of their cache key hash - e.g. every item with a key `73*` is removed.

* When running in parallel, cache writes could fail with a system error due to a race condition. This occurs if one worker invalidates an item beginning e.g. `73*` after another worker checks/creates the `73/..` directory but before it attempts to move the written file into the final path.

The race condition was a particular problem when running in parallel in `--fix` mode on a project with lots of files changing e.g. when starting to use ECS for the first time.

We had a high rate of silent failures with exit code 1, after adding #51 we saw lots of errors like:
```
 [ERROR] System error: "Cannot rename                                                                                   
         "/tmp/changed_files_detectorenv_f2d160048c6d2d58_TEST_SUFFIX_d6a6699db4dace4c93903fb2778d6006_11.1.16/m0hi53tjd
         j.tmp" to                                                                                                      
         "/tmp/changed_files_detectorenv_f2d160048c6d2d58_TEST_SUFFIX_d6a6699db4dace4c93903fb2778d6006_11.1.16/02/fe/02f
         e71fb03397faf87ff802a32437f64dc43f6ff.php":                                                                    
         rename(/tmp/changed_files_detectorenv_f2d160048c6d2d58_TEST_SUFFIX_d6a6699db4dace4c93903fb2778d6006_11.1.16/m0h
         i53tjdj.tmp,/tmp/changed_files_detectorenv_f2d160048c6d2d58_TEST_SUFFIX_d6a6699db4dace4c93903fb2778d6006_11.1.1
         6/02/fe/02fe71fb03397faf87ff802a32437f64dc43f6ff.php): No such file or directory"Run ECS with "--debug" option 
         and post the report here: https://github.com/symplify/symplify/issues/new in                                   
         {source file path redacted} 
```

I think this *may* be the root cause of #29 although obviously can't be certain unless/until we can see the actual system errors those users are encountering.

