### PR TITLE
DX: Add composer keywords (#55

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -2,6 +2,7 @@
     "name": "symplify/easy-coding-standard",
     "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer",
     "license": "MIT",
+    "keywords": ["dev"],
     "bin": [
         "bin/ecs"
     ],

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -2,7 +2,7 @@
     "name": "symplify/easy-coding-standard",
     "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer",
     "license": "MIT",
-    "keywords": ["dev", "code style", "automation", "fixer"],
+    "keywords": ["static analysis", "code style", "automation", "fixer"],
     "bin": [
         "bin/ecs"
     ],

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -2,7 +2,7 @@
     "name": "symplify/easy-coding-standard",
     "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer",
     "license": "MIT",
-    "keywords": ["dev"],
+    "keywords": ["dev", "code style", "automation", "fixer"],
     "bin": [
         "bin/ecs"
     ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "symplify/easy-coding-standard",
     "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer.",
     "license": "MIT",
-    "keywords": ["dev", "code style", "automation", "fixer"],
+    "keywords": ["static analysis", "code style", "automation", "fixer"],
     "bin": [
         "bin/ecs"
     ],

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "symplify/easy-coding-standard",
     "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer.",
     "license": "MIT",
+    "keywords": ["dev"],
     "bin": [
         "bin/ecs"
     ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "symplify/easy-coding-standard",
     "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer.",
     "license": "MIT",
-    "keywords": ["dev"],
+    "keywords": ["dev", "code style", "automation", "fixer"],
     "bin": [
         "bin/ecs"
     ],


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency