### PR TITLE
Update migration blog links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 Are you already using another tool?
 
-- [How to Migrate from PHP_CodeSniffer](https://tomasvotruba.com/blog/2018/06/04/how-to-migrate-from-php-code-sniffer-to-easy-coding-standard/#comment-4086561141)
-- [How to Migrate from PHP CS Fixer](https://tomasvotruba.com/blog/2018/06/07/how-to-migrate-from-php-cs-fixer-to-easy-coding-standard/)
+- [How to Migrate from PHP_CodeSniffer](https://tomasvotruba.com/blog/2018/06/04/how-to-migrate-from-php-code-sniffer-to-easy-coding-standard)
+- [How to Migrate from PHP CS Fixer](https://tomasvotruba.com/blog/2018/06/07/how-to-migrate-from-php-cs-fixer-to-easy-coding-standard)
 
 <br>
 


### PR DESCRIPTION
I've noticed an unnecessary comment anchor being appended to blog links, along with a `/` suffix that causes errors.

![img](https://user-images.githubusercontent.com/31698606/219909546-73df0bc3-451a-4db4-8bd3-c680888af439.png)
