### PR TITLE
Use strpos() instead of str_starts_with() for PHP 7.2 compatibility

### DIFF
--- a/build/target-repository/bootstrap.php
+++ b/build/target-repository/bootstrap.php
@@ -14,7 +14,7 @@ spl_autoload_register(static function (string $class): void {
     }
 
     // load prefixed or native class, e.g. for running tests
-    if (str_starts_with($class, 'ECSPrefix') || str_starts_with($class, 'Symplify\\')) {
+    if (strpos($class, 'ECSPrefix') === 0 || strpos($class, 'Symplify\\') === 0) {
         if ($composerAutoloader === null) {
             // prefixed version autoload
             $composerAutoloader = require __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
[`str_starts_with()`](https://www.php.net/str_starts_with) is a function introduced in PHP 8.0, so it cannot be used for PHP 7.2.

```
tadsan % ./vendor/bin/phpunit
PHP Fatal error:  Uncaught Error: Call to undefined function str_starts_with() in /home/tadsan/myproj/vendor/symplify/easy-coding-standard/bootstrap.php:17
Stack trace:
#0 [internal function]: {closure}('modules')
#1 [internal function]: spl_autoload_call('modules')
#2 /home/tadsan/myproj/vendor/phpunit/phpunit/src/Framework/TestSuite.php(176): class_exists('modules', true)
#3 /home/tadsan/myproj/vendor/phpunit/phpunit/src/TextUI/TestSuiteMapper.php(45): PHPUnit\Framework\TestSuite->__construct('modules')
#4 /home/tadsan/myproj/vendor/phpunit/phpunit/src/TextUI/Command.php(391): PHPUnit\TextUI\TestSuiteMapper->map(Object(PHPUnit\TextUI\XmlConfiguration\TestSuiteCollection), '')
#5 /home/tadsan/myproj/vendor/phpunit/phpunit/src/TextUI/Command.php(112): PHPUnit\TextUI\Command->handleArguments(Array)
#6 /home/tadsan/myproj/vendor/phpunit/phpunit/src/TextUI/Command.php(97): PHPUnit\TextUI\Command->run(Array, true)
#7 phpvfscomposer:///home/tadsa in /home/tadsan/myproj/vendor/phpunit/phpunit/src/TextUI/Command.php on line 99
```

I noticed this problem when trying to test PHP 7 on a small in-house library that hadn't been maintained for a long time.

It seems that this problem was hidden, probably because many applications rely on [symfony/polyfill-php80](https://github.com/symfony/polyfill-php80). Another workaround is to add `symfony/polyfill-php80` to this package's dependencies, but this is best avoided as users may unintentionally use `str_starts_with()`.