### PR TITLE
Simplify FileCacheStorage

### DIFF
--- a/packages/Caching/ValueObject/Storage/FileCacheStorage.php
+++ b/packages/Caching/ValueObject/Storage/FileCacheStorage.php
@@ -48,7 +48,6 @@ final class FileCacheStorage
         $this->fileSystem->mkdir($cacheFilePaths->getFirstDirectory());
         $this->fileSystem->mkdir($cacheFilePaths->getSecondDirectory());
 
-        $tmpPath = sprintf('%s/%s.tmp', $this->directory, Random::generate());
         $errorBefore = error_get_last();
         $exported = @var_export(new CacheItem($variableKey, $data), true);
         $errorAfter = error_get_last();
@@ -65,10 +64,7 @@ final class FileCacheStorage
         }
 
         $variableFileContent = sprintf("<?php declare(strict_types = 1);\n\nreturn %s;", $exported);
-        $this->fileSystem->dumpFile($tmpPath, $variableFileContent);
-
-        $this->fileSystem->rename($tmpPath, $cacheFilePaths->getFilePath(), true);
-        $this->fileSystem->remove($tmpPath);
+        $this->fileSystem->dumpFile($cacheFilePaths->getFilePath(), $variableFileContent);
     }
 
     public function clean(string $cacheKey): void


### PR DESCRIPTION
while investaging another issue I noticed that the FileCacheStorage is doing some temp-file magic, which symfony/filesystem already covers under the hood.

meaning `fileSystem->dumpFile()` is already using a temp file to make sure we get a atomic file operation.
we don't need another wrap-arround temp files which also tries to make it atomic.

see https://github.com/symfony/symfony/blob/3d380c938fbdae38579c201a15d357bdab29bc45/src/Symfony/Component/Filesystem/Filesystem.php#L671-L682