### PR TITLE
Remove codesniffer tests in releases

### DIFF
--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -28,6 +28,11 @@ jobs:
             # but no dev packages
             -   run: composer update --no-dev
 
+            # remove code-sniffer tests
+            -   run: |
+                    rm -rf vendor/squizlabs/php_codesniffer/tests/
+                    rm -rf vendor/squizlabs/php_codesniffer/src/Standards/*/Tests/
+
             # get rector to "rector-local" directory, to avoid downgrading itself in the /vendor
             -   run: mkdir rector-local
             -   run: composer require rector/rector --working-dir rector-local


### PR DESCRIPTION
closes https://github.com/easy-coding-standard/easy-coding-standard/issues/75

I have tested the commands locally, but was not able to verify the actual release build.
We should double check after release the files are actually gone.