### PR TITLE
chore(deps): update PHP-CS-Fixer to ^3.22.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": ">=8.1",
         "composer/xdebug-handler": "^3.0",
-        "friendsofphp/php-cs-fixer": "^3.18",
+        "friendsofphp/php-cs-fixer": "^3.22.0",
         "nette/utils": "^3.2",
         "squizlabs/php_codesniffer": "^3.7.2",
         "sebastian/diff": "^5.0",


### PR DESCRIPTION
Hi,

This PR upgrades PHP-CS-Fixer to the latest version 3.22.0 (which contains https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7002 :eyes:).

Thanks.