### PR TITLE
Autowire the whitespace aware fixer in the ruleWithConfiguration() method

### DIFF
--- a/src/Config/ECSConfig.php
+++ b/src/Config/ECSConfig.php
@@ -82,7 +82,7 @@ final class ECSConfig extends Container
     }
 
     /**
-     * @param class-string $checkerClass
+     * @param class-string<Sniff|FixerInterface> $checkerClass
      * @param mixed[] $configuration
      */
     public function ruleWithConfiguration(string $checkerClass, array $configuration): void

--- a/src/Config/ECSConfig.php
+++ b/src/Config/ECSConfig.php
@@ -94,6 +94,7 @@ final class ECSConfig extends Container
         // tag for autowiring of tagged_iterator()
         $interfaceTag = is_a($checkerClass, Sniff::class, true) ? Sniff::class : FixerInterface::class;
         $this->tag($checkerClass, $interfaceTag);
+        $this->autowireWhitespaceAwareFixer($checkerClass);
 
         if (is_a($checkerClass, FixerInterface::class, true)) {
             Assert::isAnyOf($checkerClass, [ConfigurableFixerInterface::class, ConfigurableRuleInterface::class]);


### PR DESCRIPTION
I ran into a `Typed property PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer::$whitespacesConfig must not be accessed before initialization` error because the following is only done in the `rule()` method but not in the `ruleWithConfiguration()` method:

https://github.com/easy-coding-standard/easy-coding-standard/blob/6f02bb5421b169a4fe3ae25f6af838d286b0a846/src/Config/ECSConfig.php#L69

If I add the fixer with the `rule()` method, everything works as expected (but obviously I cannot configure the fixer then).