### PR TITLE
Use mb_strlen() for symfony console helper

### DIFF
--- a/patches/symfony-console-helper-helper-php.patch
+++ b/patches/symfony-console-helper-helper-php.patch
@@ -4,7 +4,7 @@
      public static function width(?string $string): int
      {
          $string ??= '';
-+        return strlen($string);
++        return mb_strlen($string);
  
          if (preg_match('//u', $string)) {
              return (new UnicodeString($string))->width(false);
@@ -12,7 +12,7 @@
      public static function length(?string $string): int
      {
          $string ??= '';
-+        return strlen($string);
++        return mb_strlen($string);
  
          if (preg_match('//u', $string)) {
              return (new UnicodeString($string))->length();

--- a/src/Utils/ParametersMerger.php
+++ b/src/Utils/ParametersMerger.php
@@ -18,7 +18,7 @@ final class ParametersMerger
             return $this->mergeLeftToRightWithCallable(
                 $left,
                 $right,
-                fn ($leftValue, $rightValue) => $this->merge($leftValue, $rightValue)
+                fn ($leftValue, $rightValue): mixed => $this->merge($leftValue, $rightValue)
             );
         }
 
@@ -44,7 +44,7 @@ final class ParametersMerger
             return $this->mergeLeftToRightWithCallable(
                 $left,
                 $right,
-                fn ($leftValue, $rightValue) => $this->mergeWithCombine($leftValue, $rightValue)
+                fn ($leftValue, $rightValue): mixed => $this->mergeWithCombine($leftValue, $rightValue)
             );
         }
 


### PR DESCRIPTION
To fix small progressbar on CI

https://github.com/easy-coding-standard/easy-coding-standard/actions/runs/5748886212/job/15582636642#step:5:10

same with

https://github.com/rectorphp/vendor-patches/commit/71ce09e629e11013ac0c2b54482777a5a9fbd861#r124978841