### PR TITLE
[DI] introduce boot() method to avoid hacking beforeResolving() closures

### DIFF
--- a/bin/ecs.php
+++ b/bin/ecs.php
@@ -63,7 +63,7 @@ final class AutoloadIncluder
     public function includeDependencyOrRepositoryVendorAutoloadIfExists(): void
     {
         // ECS' vendor is already loaded
-        if (class_exists('Symplify\EasyCodingStandard\DependencyInjection\NewContainerFactory')) {
+        if (class_exists('Symplify\EasyCodingStandard\DependencyInjection\LazyContainerFactory')) {
             return;
         }
 

--- a/src/Config/ECSConfig.php
+++ b/src/Config/ECSConfig.php
@@ -12,6 +12,9 @@ use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\WhitespacesFixerConfig;
+use Symplify\EasyCodingStandard\DependencyInjection\CompilerPass\ConflictingCheckersCompilerPass;
+use Symplify\EasyCodingStandard\DependencyInjection\CompilerPass\RemoveExcludedCheckersCompilerPass;
+use Symplify\EasyCodingStandard\DependencyInjection\CompilerPass\RemoveMutualCheckersCompilerPass;
 use Symplify\EasyCodingStandard\DependencyInjection\SimpleParameterProvider;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\RuleDocGenerator\Contract\ConfigurableRuleInterface;
@@ -224,6 +227,18 @@ final class ECSConfig extends Container
         Assert::isCallable($closureFilePath);
 
         $closureFilePath($self);
+    }
+
+    public function boot(): void
+    {
+        $removeExcludedCheckersCompilerPass = new RemoveExcludedCheckersCompilerPass();
+        $removeExcludedCheckersCompilerPass->process($this);
+
+        $removeMutualCheckersCompilerPass = new RemoveMutualCheckersCompilerPass();
+        $removeMutualCheckersCompilerPass->process($this);
+
+        $conflictingCheckersCompilerPass = new ConflictingCheckersCompilerPass();
+        $conflictingCheckersCompilerPass->process($this);
     }
 
     /**

--- a/src/DependencyInjection/EasyCodingStandardContainerFactory.php
+++ b/src/DependencyInjection/EasyCodingStandardContainerFactory.php
@@ -16,7 +16,7 @@ final class EasyCodingStandardContainerFactory
     public function createFromFromInput(ArgvInput $argvInput): Container
     {
         // $easyCodingStandardKernel = new EasyCodingStandardKernel();
-        $newContainerFactory = new NewContainerFactory();
+        $newContainerFactory = new LazyContainerFactory();
 
         $inputConfigFiles = [];
         $rootECSConfig = getcwd() . DIRECTORY_SEPARATOR . 'ecs.php';

--- a/src/DependencyInjection/EasyCodingStandardContainerFactory.php
+++ b/src/DependencyInjection/EasyCodingStandardContainerFactory.php
@@ -16,7 +16,7 @@ final class EasyCodingStandardContainerFactory
     public function createFromFromInput(ArgvInput $argvInput): Container
     {
         // $easyCodingStandardKernel = new EasyCodingStandardKernel();
-        $newContainerFactory = new LazyContainerFactory();
+        $lazyContainerFactory = new LazyContainerFactory();
 
         $inputConfigFiles = [];
         $rootECSConfig = getcwd() . DIRECTORY_SEPARATOR . 'ecs.php';
@@ -31,7 +31,8 @@ final class EasyCodingStandardContainerFactory
             $inputConfigFiles[] = $rootECSConfig;
         }
 
-        $container = $newContainerFactory->create($inputConfigFiles);
+        $container = $lazyContainerFactory->create($inputConfigFiles);
+        $container->boot();
 
         if ($inputConfigFiles !== []) {
             // for cache invalidation on config change

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -37,7 +37,7 @@ use Symplify\EasyCodingStandard\SniffRunner\Application\SniffFileProcessor;
 use Symplify\EasyCodingStandard\SniffRunner\DataCollector\SniffMetadataCollector;
 use Webmozart\Assert\Assert;
 
-final class NewContainerFactory
+final class LazyContainerFactory
 {
     /**
      * @param string[] $configFiles

--- a/src/Testing/PHPUnit/AbstractTestCase.php
+++ b/src/Testing/PHPUnit/AbstractTestCase.php
@@ -15,8 +15,10 @@ abstract class AbstractTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $newContainerFactory = new LazyContainerFactory();
-        $this->container = $newContainerFactory->create();
+        $lazyContainerFactory = new LazyContainerFactory();
+
+        $this->container = $lazyContainerFactory->create();
+        $this->container->boot();
     }
 
     /**
@@ -27,8 +29,10 @@ abstract class AbstractTestCase extends TestCase
         Assert::allString($configs);
         Assert::allFile($configs);
 
-        $newContainerFactory = new LazyContainerFactory();
-        $this->container = $newContainerFactory->create($configs);
+        $lazyContainerFactory = new LazyContainerFactory();
+        $this->container = $lazyContainerFactory->create($configs);
+
+        $this->container->boot();
     }
 
     /**

--- a/src/Testing/PHPUnit/AbstractTestCase.php
+++ b/src/Testing/PHPUnit/AbstractTestCase.php
@@ -6,7 +6,7 @@ namespace Symplify\EasyCodingStandard\Testing\PHPUnit;
 
 use Illuminate\Container\Container;
 use PHPUnit\Framework\TestCase;
-use Symplify\EasyCodingStandard\DependencyInjection\NewContainerFactory;
+use Symplify\EasyCodingStandard\DependencyInjection\LazyContainerFactory;
 use Webmozart\Assert\Assert;
 
 abstract class AbstractTestCase extends TestCase
@@ -15,7 +15,7 @@ abstract class AbstractTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $newContainerFactory = new NewContainerFactory();
+        $newContainerFactory = new LazyContainerFactory();
         $this->container = $newContainerFactory->create();
     }
 
@@ -27,7 +27,7 @@ abstract class AbstractTestCase extends TestCase
         Assert::allString($configs);
         Assert::allFile($configs);
 
-        $newContainerFactory = new NewContainerFactory();
+        $newContainerFactory = new LazyContainerFactory();
         $this->container = $newContainerFactory->create($configs);
     }
 


### PR DESCRIPTION
Mirror to https://github.com/rectorphp/rector-src/pull/4937/files

---

Based on reddit feedback - https://www.reddit.com/r/PHP/comments/16cpxq1/comment/jzmy3bt/?utm_source=reddit&utm_medium=web2x&context=3,

this method is more commonly known in Laravel to handle post-process: https://laravel.com/docs/10.x/providers#the-boot-method