### PR TITLE
[Scoped] Exclude vendor/symfony/console/Debug/CliRequest.php from parallel-lint PHP 7.2 syntax check

### DIFF
--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -48,7 +48,7 @@ jobs:
                     coverage: none
 
             -   run: composer global require php-parallel-lint/php-parallel-lint --ansi
-            -   run: /home/runner/.composer/vendor/bin/parallel-lint src packages vendor --exclude vendor/symfony/dependency-injection/Attribute/Autowire.php --exclude vendor/symfony/config/Definition/Dumper/XmlReferenceDumper.php
+            -   run: /home/runner/.composer/vendor/bin/parallel-lint src packages vendor --exclude vendor/symfony/dependency-injection/Attribute/Autowire.php --exclude vendor/symfony/config/Definition/Dumper/XmlReferenceDumper.php --exclude vendor/symfony/console/Debug/CliRequest.php
 
             # restore build php version
             -

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "nette/utils": "^3.2",
         "sebastian/diff": "^5.0",
         "phpcsstandards/php_codesniffer": "^3.7.2",
-        "symfony/console": "6.3.*",
+        "symfony/console": "^6.3",
         "symfony/finder": "^6.3",
         "symplify/coding-standard": "^12.0.4",
         "symplify/easy-parallel": "^11.1",


### PR DESCRIPTION
Similar with what rector-src doing, this exclude `vendor/symfony/console/Debug/CliRequest.php` from php 7.2 syntax check, because it extends `symfony/http-foundation` Request which not exists, so named arg can't be downgraded.

The `CliRequest` seems used internally and under `Debug` namespace so it should be safe to exclude it, I tried with `--debug` on rector side on php 7.2 and it seems still working ok.