### PR TITLE
php-cs-fixer, assert type of T_NULLSAFE_OBJECT_OPERATOR is int

### DIFF
--- a/bin/ecs.php
+++ b/bin/ecs.php
@@ -96,7 +96,7 @@ final class AutoloadIncluder
             require_once $possiblePhpCodeSnifferAutoloadPath;
         }
 
-        // initalize token with INT type, otherwise php-cs-fixer and php-parser breaks
+        // initialize token with INT type, otherwise php-cs-fixer and php-parser breaks
         if (! defined('T_MATCH')) {
             define('T_MATCH', 5000);
         }
@@ -107,6 +107,10 @@ final class AutoloadIncluder
 
         if (! defined('T_ENUM')) {
             define('T_ENUM', 5015);
+        }
+
+        if (! defined('T_NULLSAFE_OBJECT_OPERATOR')) {
+            define('T_NULLSAFE_OBJECT_OPERATOR', 5020);
         }
 
         // for PHP_CodeSniffer

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -122,7 +122,7 @@ final class LazyContainerFactory
     private function loadPHPCodeSnifferConstants(): void
     {
         if (! defined('PHP_CODESNIFFER_VERBOSITY')) {
-            // initalize token with INT type, otherwise php-cs-fixer and php-parser breaks
+            // initialize token with INT type, otherwise php-cs-fixer and php-parser breaks
             if (! defined('T_MATCH')) {
                 define('T_MATCH', 5000);
             }
@@ -133,6 +133,10 @@ final class LazyContainerFactory
 
             if (! defined('T_ENUM')) {
                 define('T_ENUM', 5015);
+            }
+
+            if (! defined('T_NULLSAFE_OBJECT_OPERATOR')) {
+                define('T_NULLSAFE_OBJECT_OPERATOR', 5020);
             }
 
             // for PHP_CodeSniffer


### PR DESCRIPTION
```
System error: "Fixing of "SomeTest.php" file by "PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer" failed:
         Argument 4 passed to PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer::applyPhpUnitClassFixWithObjectOperator()
         must be of the type int, string given, called in                                                               
         vendor/symplify/easy-coding-standard/vendor/friendsofphp/php-cs-fixer/src/Fixer/PhpUnit/
         PhpUnitExpectationFixer.php on line 133 in file                                                                
         vendor/symplify/easy-coding-standard/vendor/friendsofphp/php-cs-fixer/src/Fixer/PhpUnit/
         PhpUnitExpectationFixer.php on line 136"Run ECS with "--debug" option and post the report here: 
         https://github.com/symplify/symplify/issues/new in SomeTest.php:159
```

```php
<?php

class SomeTest extends PHPUnit\Framework\TestCase { }
```

with `PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer` triggers this error.