### PR TITLE
No "strict" set in "common"

### DIFF
--- a/config/set/common.php
+++ b/config/set/common.php
@@ -14,7 +14,6 @@ return static function (ECSConfig $ecsConfig): void {
         SetList::NAMESPACES,
         SetList::PHPUNIT,
         SetList::SPACES,
-        SetList::STRICT,
         SetList::CLEAN_CODE,
     ]);
 };

--- a/config/set/common/control-structures.php
+++ b/config/set/common/control-structures.php
@@ -11,6 +11,7 @@ use PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\ExplicitIndirectVariableFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\FunctionToConstantFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer;
 use PhpCsFixer\Fixer\Operator\NewWithBracesFixer;
 use PhpCsFixer\Fixer\Operator\StandardizeIncrementFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitMethodCasingFixer;
@@ -31,6 +32,7 @@ return static function (ECSConfig $ecsConfig): void {
         NoUselessElseFixer::class,
         SingleQuoteFixer::class,
         OrderedClassElementsFixer::class,
+        IsNullFixer::class,
     ]);
 
     $ecsConfig->ruleWithConfiguration(SingleClassElementPerStatementFixer::class, [

--- a/config/set/common/strict.php
+++ b/config/set/common/strict.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
@@ -11,7 +10,6 @@ use Symplify\EasyCodingStandard\Config\ECSConfig;
 return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->rules([
         StrictComparisonFixer::class,
-        IsNullFixer::class,
         StrictParamFixer::class,
         DeclareStrictTypesFixer::class,
     ]);

--- a/config/set/common/strict.php
+++ b/config/set/common/strict.php
@@ -8,9 +8,5 @@ use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return static function (ECSConfig $ecsConfig): void {
-    $ecsConfig->rules([
-        StrictComparisonFixer::class,
-        StrictParamFixer::class,
-        DeclareStrictTypesFixer::class,
-    ]);
+    $ecsConfig->rules([StrictComparisonFixer::class, StrictParamFixer::class, DeclareStrictTypesFixer::class]);
 };


### PR DESCRIPTION
Even better use Rector type set instead, as type coverage needs static analysis context. Coding standard tool do not have that and can cause code run to fail.	
