### PR TITLE
Add cleanCode parameter and allow strict even when using common (since it is not part of common)

### DIFF
--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -158,8 +158,6 @@ final class ECSConfigBuilder
         bool $common = false,
         /** @see SetList::SYMPLIFY */
         bool $symplify = false,
-        /** @see SetList::CLEAN_CODE */
-        bool $cleanCode = false,
 
         // common sets
         /** @see SetList::ARRAY */
@@ -178,6 +176,8 @@ final class ECSConfigBuilder
         bool $phpunit = false,
         /** @see SetList::STRICT */
         bool $strict = false,
+        /** @see SetList::CLEAN_CODE */
+        bool $cleanCode = false,
     ): self {
         if ($psr12) {
             $this->sets[] = SetList::PSR_12;

--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -158,6 +158,8 @@ final class ECSConfigBuilder
         bool $common = false,
         /** @see SetList::SYMPLIFY */
         bool $symplify = false,
+        /** @see SetList::CLEAN_CODE */
+        bool $cleanCode = false,
 
         // common sets
         /** @see SetList::ARRAY */
@@ -215,13 +217,17 @@ final class ECSConfigBuilder
                 $this->sets[] = SetList::PHPUNIT;
             }
 
-            if ($strict) {
-                $this->sets[] = SetList::STRICT;
-            }
-
             if ($comments) {
                 $this->sets[] = SetList::COMMENTS;
             }
+        }
+
+        if ($strict) {
+            $this->sets[] = SetList::STRICT;
+        }
+
+        if ($cleanCode) {
+            $this->sets[] = SetList::CLEAN_CODE;
         }
 
         if ($symplify) {


### PR DESCRIPTION
FIxes #165