### PR TITLE
[Configuration] Add ability to disable parallel on ECSConfigBuilder

### DIFF
--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -110,6 +110,8 @@ final class ECSConfigBuilder
                 maxNumberOfProcess: $this->parallelMaxNumberOfProcess,
                 jobSize: $this->parallelJobSize
             );
+        } else {
+            $ecsConfig->disableParallel();
         }
     }
 


### PR DESCRIPTION
when `$ecsConfig->withoutParallel()` is called, the `false` value of `parallel` property should call `$ecsConfig->disableParallel()`, so `else` is needed.