### PR TITLE
Fix syntax error in templates on run on php < 8

### DIFF
--- a/templates/ecs.php.dist
+++ b/templates/ecs.php.dist
@@ -16,10 +16,12 @@ __PATHS__
     ])
 
     // add sets - group of rules
-    ->withPreparedSets(
-        arrays: true,
+   // ->withPreparedSets(
+        // arrays: true,
         // namespaces: true,
         // spaces: true,
         // docblocks: true,
         // comments: true,
-    );
+    // )
+     
+     ;


### PR DESCRIPTION
@gamel this should fix https://github.com/easy-coding-standard/easy-coding-standard/issues/171