### PR TITLE
Fix paths override each other on ECSConfigBuilder

### DIFF
--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -77,7 +77,11 @@ final class ECSConfigBuilder
     public function __invoke(ECSConfig $ecsConfig): void
     {
         $ecsConfig->sets($this->sets);
-        $ecsConfig->paths($this->paths);
+
+        if ($this->paths !== []) {
+            $ecsConfig->paths($this->paths);
+        }
+        
         $ecsConfig->skip($this->skip);
         $ecsConfig->rules($this->rules);
         $ecsConfig->rulesWithConfiguration($this->rulesWithConfiguration);


### PR DESCRIPTION
@TomasVotruba this is inspired by rector PR at:

- https://github.com/rectorphp/rector-src/pull/5561