### PR TITLE
[Configuration] Fix parallel config always replaced by next config as default to true

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -17,6 +17,7 @@ if (StaticVersionResolver::PACKAGE_VERSION !== '@package_version@') {
 $cacheNamespace = str_replace(DIRECTORY_SEPARATOR, '_', getcwd());
 
 return ECSConfig::configure()
+    ->withParallel()
     ->withSpacing(indentation: Option::INDENTATION_SPACES, lineEnding: PHP_EOL)
     ->withCache(directory: $cacheDirectory, namespace: $cacheNamespace)
     ->withFileExtensions(['php'])

--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -63,10 +63,7 @@ final class ECSConfigBuilder
 
     private ?string $lineEnding = null;
 
-    /**
-     * Enabled by default
-     */
-    private bool $parallel = true;
+    private ?bool $parallel = null;
 
     private int $parallelTimeoutSeconds = 120;
 
@@ -108,14 +105,16 @@ final class ECSConfigBuilder
 
         $ecsConfig->dynamicSets($this->dynamicSets);
 
-        if ($this->parallel) {
-            $ecsConfig->parallel(
-                seconds: $this->parallelTimeoutSeconds,
-                maxNumberOfProcess: $this->parallelMaxNumberOfProcess,
-                jobSize: $this->parallelJobSize
-            );
-        } else {
-            $ecsConfig->disableParallel();
+        if ($this->parallel !== null) {
+            if ($this->parallel) {
+                $ecsConfig->parallel(
+                    seconds: $this->parallelTimeoutSeconds,
+                    maxNumberOfProcess: $this->parallelMaxNumberOfProcess,
+                    jobSize: $this->parallelJobSize
+                );
+            } else {
+                $ecsConfig->disableParallel();
+            }
         }
     }
 


### PR DESCRIPTION
@Reinis here to fix https://github.com/easy-coding-standard/easy-coding-standard/issues/180

The existing `ECSConfigBuilder::$parallel` property is default to `true`, so the `$ecsConfig->parallel()` is always called, instead, it needs to be nullable bool:

```php
private ?bool $parallel = null;
```

with default to `null`, and call `parallel()` or `disableParallel()` when it enabled/disabled:

```php
        if ($this->parallel !== null) {
            if ($this->parallel) {
                $ecsConfig->parallel(
                    seconds: $this->parallelTimeoutSeconds,
                    maxNumberOfProcess: $this->parallelMaxNumberOfProcess,
                    jobSize: $this->parallelJobSize
                );
            } else {
                $ecsConfig->disableParallel();
            }
        }
```

To ensure it enabled by default on the project, I set entry point in `config/config.php`:

```php
# config/config.php
return ECSConfig::configure()
    ->withParallel()
```

I tried in this repo and it seems working ok 👍 