### PR TITLE
Dynamic sets should be configured after sets

### DIFF
--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -77,6 +77,10 @@ final class ECSConfigBuilder
             $ecsConfig->sets($this->sets);
         }
 
+        if ($this->dynamicSets !== []) {
+            $ecsConfig->dynamicSets($this->dynamicSets);
+        }
+
         if ($this->paths !== []) {
             $ecsConfig->paths($this->paths);
         }
@@ -111,10 +115,6 @@ final class ECSConfigBuilder
 
         if ($this->lineEnding !== null) {
             $ecsConfig->lineEnding($this->lineEnding);
-        }
-
-        if ($this->dynamicSets !== []) {
-            $ecsConfig->dynamicSets($this->dynamicSets);
         }
 
         if ($this->parallel !== null) {


### PR DESCRIPTION
I ran into the same issue as stated in #186 
When trying to override a rule in a dynamic set using `ruleWithConfiguration`, when using the ECSConfigBuilder, the new configuration is not honored, and the configuration from the dynamic set is used.

Like sets, dynamicSets should be defined before anything else, thus allowing for rules and rulesWithConfiguration to override the defaults in the predefined sets.