### PR TITLE
Less memory hungry FnMatchPathNormalizer: reduced by ~35-45%

### DIFF
--- a/src/Skipper/FileSystem/FnMatchPathNormalizer.php
+++ b/src/Skipper/FileSystem/FnMatchPathNormalizer.php
@@ -11,34 +11,16 @@ use Nette\Utils\Strings;
  */
 final class FnMatchPathNormalizer
 {
-    /**
-     * @var string
-     * @see https://regex101.com/r/ZB2dFV/2
-     */
-    private const ONLY_ENDS_WITH_ASTERISK_REGEX = '#^[^*](.*?)\*$#';
-
-    /**
-     * @var string
-     * @see https://regex101.com/r/aVUDjM/2
-     */
-    private const ONLY_STARTS_WITH_ASTERISK_REGEX = '#^\*(.*?)[^*]$#';
-
     public function normalizeForFnmatch(string $path): string
     {
-        // ends with *
-        if (Strings::match($path, self::ONLY_ENDS_WITH_ASTERISK_REGEX)) {
-            return '*' . $path;
-        }
-
-        // starts with *
-        if (Strings::match($path, self::ONLY_STARTS_WITH_ASTERISK_REGEX)) {
-            return $path . '*';
+        if (str_ends_with($path, '*') || str_starts_with($path, '*')) {
+            return '*' . trim($path, '*') . '*';
         }
 
         if (\str_contains($path, '..')) {
-            /** @var string|false $path */
-            $path = realpath($path);
-            if ($path === false) {
+            /** @var string|false $realPath */
+            $realPath = realpath($path);
+            if ($realPath === false) {
                 return '';
             }
         }

--- a/src/Skipper/FileSystem/FnMatchPathNormalizer.php
+++ b/src/Skipper/FileSystem/FnMatchPathNormalizer.php
@@ -23,6 +23,7 @@ final class FnMatchPathNormalizer
             if ($realPath === false) {
                 return '';
             }
+            return $realPath;
         }
 
         return $path;

--- a/src/Skipper/FileSystem/FnMatchPathNormalizer.php
+++ b/src/Skipper/FileSystem/FnMatchPathNormalizer.php
@@ -23,6 +23,7 @@ final class FnMatchPathNormalizer
             if ($realPath === false) {
                 return '';
             }
+
             return $realPath;
         }
 


### PR DESCRIPTION
on my project it looks pretty good (1 GB less memory use):

![grafik](https://github.com/easy-coding-standard/easy-coding-standard/assets/120441/7b095343-2043-4629-9f71-41f0c8c5781e)


similar change as in https://github.com/rectorphp/rector-src/pull/4153