### PR TITLE
Remove repeated calls to `EasyCodingStandardStyle->isDebug()`

### DIFF
--- a/src/FixerRunner/Application/FixerFileProcessor.php
+++ b/src/FixerRunner/Application/FixerFileProcessor.php
@@ -31,6 +31,8 @@ final class FixerFileProcessor implements FileProcessorInterface
      */
     private array $fixers = [];
 
+    private readonly bool $isDebug;
+
     /**
      * @param FixerInterface[] $fixers
      */
@@ -44,6 +46,7 @@ final class FixerFileProcessor implements FileProcessorInterface
         array $fixers
     ) {
         $this->fixers = $this->sortFixers($fixers);
+        $this->isDebug = $easyCodingStandardStyle->isDebug();
     }
 
     /**
@@ -148,7 +151,7 @@ final class FixerFileProcessor implements FileProcessorInterface
         }
 
         // show current fixer in --debug / -vvv
-        if ($this->easyCodingStandardStyle->isDebug()) {
+        if ($this->isDebug) {
             $this->easyCodingStandardStyle->writeln('     [fixer] ' . $fixer::class);
         }
 


### PR DESCRIPTION
repeating `isDebug` calls are showing up in the top 6 of memory consuming methods, measured by blackfire:

![grafik](https://github.com/easy-coding-standard/easy-coding-standard/assets/120441/35efbbd3-cdcf-433b-8866-4122622d17d5)
