### PR TITLE
Implement `--no-diffs` CLI Option

### DIFF
--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -24,6 +24,7 @@ final class ConfigurationFactory
         $shouldClearCache = (bool) $input->getOption(Option::CLEAR_CACHE);
         $showProgressBar = $this->canShowProgressBar($input);
         $showErrorTable = ! (bool) $input->getOption(Option::NO_ERROR_TABLE);
+        $showDiffs = ! (bool) $input->getOption(Option::NO_DIFFS);
         $parallelPort = (string) $input->getOption(Option::PARALLEL_PORT);
         $parallelIdentifier = (string) $input->getOption(Option::PARALLEL_IDENTIFIER);
 
@@ -50,7 +51,8 @@ final class ConfigurationFactory
             $config,
             $parallelPort,
             $parallelIdentifier,
-            $memoryLimit
+            $memoryLimit,
+            $showDiffs
         );
     }
 

--- a/src/Console/Command/AbstractCheckCommand.php
+++ b/src/Console/Command/AbstractCheckCommand.php
@@ -40,6 +40,12 @@ abstract class AbstractCheckCommand extends Command
             InputOption::VALUE_NONE,
             'Hide error table. Useful e.g. for fast check of error count.'
         );
+        $this->addOption(
+            Option::NO_DIFFS,
+            null,
+            InputOption::VALUE_NONE,
+            'Hide diffs of changed files. Useful e.g. for nicer CI output.'
+        );
 
         $this->addOption(
             Option::OUTPUT_FORMAT,

--- a/src/Console/Output/ConsoleOutputFormatter.php
+++ b/src/Console/Output/ConsoleOutputFormatter.php
@@ -30,7 +30,9 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
      */
     public function report(ErrorAndDiffResult $errorAndDiffResult, Configuration $configuration): int
     {
-        $this->reportFileDiffs($errorAndDiffResult->getFileDiffs());
+        if ($configuration->shouldShowDiffs()) {
+            $this->reportFileDiffs($errorAndDiffResult->getFileDiffs());
+        }
 
         $this->easyCodingStandardStyle->newLine(1);
 

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -22,7 +22,8 @@ final readonly class Configuration
         private ?string $config = null,
         private string | null $parallelPort = null,
         private string | null $parallelIdentifier = null,
-        private string | null $memoryLimit = null
+        private string | null $memoryLimit = null,
+        private bool $showDiffs = true
     ) {
     }
 
@@ -44,6 +45,11 @@ final readonly class Configuration
     public function shouldShowErrorTable(): bool
     {
         return $this->showErrorTable;
+    }
+
+    public function shouldShowDiffs(): bool
+    {
+        return $this->showDiffs;
     }
 
     /**

--- a/src/ValueObject/Option.php
+++ b/src/ValueObject/Option.php
@@ -32,6 +32,11 @@ final class Option
     public const OUTPUT_FORMAT = 'output-format';
 
     /**
+     * @var string
+     */
+    public const NO_DIFFS = 'no-diffs';
+
+    /**
      * @api
      * @deprecated Use @see \Symplify\EasyCodingStandard\Config\ECSConfig::skip()
      * @var string


### PR DESCRIPTION
replicated the rector implementation of `--no-diffs` 1:1

closes https://github.com/easy-coding-standard/easy-coding-standard/issues/191

```
$ time php ../easy-coding-standard/bin/ecs check

**... snip walls of text of diff**
                                                                                                                        
 [WARNING] 885 errors are fixable! Just add "--fix" to console command and rerun to apply.                              

real    0m50.121s
user    0m0.000s
sys     0m0.000s

$ time php ../easy-coding-standard/bin/ecs check --no-diffs
 890/890 [============================] 100%

                                                                                                                        
 [WARNING] 885 errors are fixable! Just add "--fix" to console command and rerun to apply.                              


real    0m42.911s
user    0m0.015s
sys     0m0.000s
`` 