### PR TITLE
Faster FileInfoMatcher

### DIFF
--- a/src/Skipper/Matcher/FileInfoMatcher.php
+++ b/src/Skipper/Matcher/FileInfoMatcher.php
@@ -61,6 +61,11 @@ final readonly class FileInfoMatcher
             return true;
         }
 
+        // realpathMatcher cannot resolve wildcards -> return early to prevent unnecessary IO
+        if (str_contains($ignoredPath, '*')) {
+            return false;
+        }
+
         return $this->realpathMatcher->match($ignoredPath, $filePath);
     }
 }


### PR DESCRIPTION
RealpathMatcher cannot resolve wildcards -> early return to prevent unnecessary IO

![grafik](https://github.com/easy-coding-standard/easy-coding-standard/assets/120441/0cb7bf3c-3464-4167-8f6c-7b9291ae6589)
