### PR TITLE
Revert "Faster FileInfoMatcher"

### DIFF
--- a/src/Skipper/Matcher/FileInfoMatcher.php
+++ b/src/Skipper/Matcher/FileInfoMatcher.php
@@ -61,11 +61,6 @@ final readonly class FileInfoMatcher
             return true;
         }
 
-        // realpathMatcher cannot resolve wildcards -> return early to prevent unnecessary IO
-        if (str_contains($ignoredPath, '*')) {
-            return false;
-        }
-
         return $this->realpathMatcher->match($ignoredPath, $filePath);
     }
 }


### PR DESCRIPTION
Reverts easy-coding-standard/easy-coding-standard#196

@staabm I am reverting due to allowed `*` in the middle of file name, see https://github.com/rectorphp/rector-src/pull/5830#pullrequestreview-2011282247