### PR TITLE
Add new output formatter for checkstyle

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -18,5 +18,8 @@
         "symplify/coding-standard": "<12.1",
         "phpcsstandards/php_codesniffer": "<3.8",
         "friendsofphp/php-cs-fixer": "<3.46"
+    },
+    "suggest": {
+        "ext-dom": "Needed to support checkstyle output format in class CheckstyleOutputFormatter"
     }
 }

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\EasyCodingStandard\Configuration;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symplify\EasyCodingStandard\Console\Output\CheckstyleOutputFormatter;
 use Symplify\EasyCodingStandard\Console\Output\JsonOutputFormatter;
 use Symplify\EasyCodingStandard\DependencyInjection\SimpleParameterProvider;
 use Symplify\EasyCodingStandard\Exception\Configuration\SourceNotFoundException;
@@ -61,6 +62,11 @@ final class ConfigurationFactory
         // --debug option shows more
         $debug = (bool) $input->getOption(Option::DEBUG);
         if ($debug) {
+            return false;
+        }
+
+        $notCheckstyleOutput = $input->getOption(Option::OUTPUT_FORMAT) !== CheckstyleOutputFormatter::NAME;
+        if (! $notCheckstyleOutput) {
             return false;
         }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -65,13 +65,9 @@ final class ConfigurationFactory
             return false;
         }
 
-        $notCheckstyleOutput = $input->getOption(Option::OUTPUT_FORMAT) !== CheckstyleOutputFormatter::NAME;
-        if (! $notCheckstyleOutput) {
-            return false;
-        }
-
-        $notJsonOutput = $input->getOption(Option::OUTPUT_FORMAT) !== JsonOutputFormatter::NAME;
-        if (! $notJsonOutput) {
+        $outputFormat = $input->getOption(Option::OUTPUT_FORMAT);
+        $formatsWithoutProgressBar = [CheckstyleOutputFormatter::NAME, JsonOutputFormatter::NAME];
+        if (in_array($outputFormat, $formatsWithoutProgressBar, true)) {
             return false;
         }
 

--- a/src/Console/Output/CheckstyleOutputFormatter.php
+++ b/src/Console/Output/CheckstyleOutputFormatter.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Console\Output;
+
+use DOMDocument;
+use DOMElement;
+use RuntimeException;
+use Symplify\EasyCodingStandard\Console\ExitCode;
+use Symplify\EasyCodingStandard\Console\Style\EasyCodingStandardStyle;
+use Symplify\EasyCodingStandard\Contract\Console\Output\OutputFormatterInterface;
+use Symplify\EasyCodingStandard\ValueObject\Configuration;
+use Symplify\EasyCodingStandard\ValueObject\Error\ErrorAndDiffResult;
+
+/**
+ * @see \Symplify\EasyCodingStandard\Tests\Console\Output\JsonOutputFormatterTest
+ */
+final readonly class CheckstyleOutputFormatter implements OutputFormatterInterface
+{
+    /**
+     * @var string
+     */
+    public const NAME = 'checkstyle';
+
+    public function __construct(
+        private EasyCodingStandardStyle $easyCodingStandardStyle,
+        private ExitCodeResolver $exitCodeResolver
+    ) {
+    }
+
+    /**
+     * @return ExitCode::*
+     */
+    public function report(ErrorAndDiffResult $errorAndDiffResult, Configuration $configuration): int
+    {
+        $checkstyleContent = $this->createCheckstyleContent($errorAndDiffResult);
+        $this->easyCodingStandardStyle->writeln($checkstyleContent);
+
+        return $this->exitCodeResolver->resolve($errorAndDiffResult, $configuration);
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    /**
+     * @api
+     */
+    public function createCheckstyleContent(ErrorAndDiffResult $errorAndDiffResult): string
+    {
+        if (! \extension_loaded('dom')) {
+            throw new RuntimeException('Cannot generate report! `ext-dom` is not available!');
+        }
+
+        $domDocument = new DOMDocument('1.0', 'UTF-8');
+
+        /** @var DOMElement $checkstyleElement */
+        $checkstyleElement = $domDocument->appendChild($domDocument->createElement('checkstyle'));
+
+        foreach ($errorAndDiffResult->getFileDiffs() as $fileDiff) {
+            /** @var DOMElement $file */
+            $file = $checkstyleElement->appendChild($domDocument->createElement('file'));
+            $file->setAttribute('name', $fileDiff->getRelativeFilePath());
+
+            foreach ($fileDiff->getAppliedCheckers() as $appliedChecker) {
+                $errorElement = $this->createError($domDocument, $appliedChecker);
+                $file->appendChild($errorElement);
+            }
+        }
+
+        $domDocument->formatOutput = true;
+
+        return (string) $domDocument->saveXML();
+    }
+
+    private function createError(DOMDocument $domDocument, string $appliedChecker): DOMElement
+    {
+        $domElement = $domDocument->createElement('error');
+        $domElement->setAttribute('severity', 'warning');
+        $domElement->setAttribute('source', 'EasyCodingStandard.' . $appliedChecker);
+        $domElement->setAttribute('message', 'Found violation(s) of type: ' . $appliedChecker);
+
+        return $domElement;
+    }
+}

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -18,6 +18,7 @@ use Symplify\EasyCodingStandard\Caching\Cache;
 use Symplify\EasyCodingStandard\Caching\CacheFactory;
 use Symplify\EasyCodingStandard\Caching\ChangedFilesDetector;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\Console\Output\CheckstyleOutputFormatter;
 use Symplify\EasyCodingStandard\Console\Output\ConsoleOutputFormatter;
 use Symplify\EasyCodingStandard\Console\Output\JsonOutputFormatter;
 use Symplify\EasyCodingStandard\Console\Output\OutputFormatterCollector;
@@ -81,6 +82,7 @@ final class LazyContainerFactory
         });
 
         // output
+        $ecsConfig->singleton(CheckstyleOutputFormatter::class);
         $ecsConfig->singleton(ConsoleOutputFormatter::class);
         $ecsConfig->singleton(JsonOutputFormatter::class);
         $ecsConfig->singleton(OutputFormatterCollector::class);

--- a/tests/Console/Output/CheckstyleOutputFormatterTest.php
+++ b/tests/Console/Output/CheckstyleOutputFormatterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Tests\Console\Output;
+
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+use Symplify\EasyCodingStandard\Console\Formatter\ColorConsoleDiffFormatter;
+use Symplify\EasyCodingStandard\Console\Output\CheckstyleOutputFormatter;
+use Symplify\EasyCodingStandard\FileSystem\StaticRelativeFilePathHelper;
+use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractTestCase;
+use Symplify\EasyCodingStandard\ValueObject\Error\ErrorAndDiffResult;
+use Symplify\EasyCodingStandard\ValueObject\Error\FileDiff;
+
+final class CheckstyleOutputFormatterTest extends AbstractTestCase
+{
+    private CheckstyleOutputFormatter $checkstyleOutputFormatter;
+
+    private ColorConsoleDiffFormatter $colorConsoleDiffFormatter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->checkstyleOutputFormatter = $this->make(CheckstyleOutputFormatter::class);
+        $this->colorConsoleDiffFormatter = $this->make(ColorConsoleDiffFormatter::class);
+    }
+
+    public function test(): void
+    {
+        $relativeFilePath = StaticRelativeFilePathHelper::resolveFromCwd(__DIR__ . '/Source/RandomFile.php');
+
+        $fileDiffs = [];
+
+        $diff = 'some diff';
+        $fileDiffs[] = new FileDiff(
+            $relativeFilePath,
+            $diff,
+            $this->colorConsoleDiffFormatter->format($diff),
+            [LineLengthFixer::class]
+        );
+
+        $diff = 'some other diff';
+        $fileDiffs[] = new FileDiff(
+            $relativeFilePath,
+            $diff,
+            $this->colorConsoleDiffFormatter->format($diff),
+            [LineLengthFixer::class]
+        );
+
+        $errorAndDiffResult = new ErrorAndDiffResult([], $fileDiffs, []);
+
+        $checkstyleContent = $this->checkstyleOutputFormatter->createCheckstyleContent($errorAndDiffResult);
+        $this->assertStringMatchesFormatFile(
+            __DIR__ . '/Fixture/expected_checkstyle_output.xml',
+            $checkstyleContent . PHP_EOL
+        );
+    }
+}

--- a/tests/Console/Output/Fixture/expected_checkstyle_output.xml
+++ b/tests/Console/Output/Fixture/expected_checkstyle_output.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+  <file name="tests/Console/Output/Source/RandomFile.php">
+    <error severity="warning" source="EasyCodingStandard.Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer" message="Found violation(s) of type: Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer"/>
+  </file>
+  <file name="tests/Console/Output/Source/RandomFile.php">
+    <error severity="warning" source="EasyCodingStandard.Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer" message="Found violation(s) of type: Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer"/>
+  </file>
+</checkstyle>


### PR DESCRIPTION
The use case for this are CI checks that add simple and easy to read annotations to GitHub pull requests via [cs2pr](https://staabm.github.io/2022/04/03/annotate-pull-request-from-checkstyle.html).

The code is adapted from PHP-CS-Fixer that already possesses this [output format](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/src/Console/Report/FixReport/CheckstyleReporter.php).

I have also added a test for this new output format.