### PR TITLE
Bump to Rector 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-webmozart-assert": "^1.2",
         "phpunit/phpunit": "^10.5",
-        "rector/rector": "^0.19",
+        "rector/rector": "^1.0",
         "symplify/phpstan-extensions": "^11.4",
         "symplify/vendor-patches": "^11.3",
         "tomasvotruba/class-leak": "^0.2",

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,7 @@ return RectorConfig::configure()
         '*/Source/*',
         '*/Fixture/*',
         __DIR__ . '/src/SniffRunner/ValueObject/File.php',
+        __DIR__ . '/scoper.php',
 
         RenameParamToMatchTypeRector::class => [__DIR__ . '/src/FixerRunner/Application/FixerFileProcessor.php'],
     ]);

--- a/rector.php
+++ b/rector.php
@@ -4,39 +4,26 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_82,
-        SetList::CODE_QUALITY,
-        SetList::DEAD_CODE,
-        SetList::CODING_STYLE,
-        SetList::TYPE_DECLARATION,
-        SetList::NAMING,
-        SetList::PRIVATIZATION,
-        SetList::EARLY_RETURN,
-    ]);
-
-    $rectorConfig->paths([
-        __DIR__ . '/ecs.php',
-        __DIR__ . '/rector.php',
-        __DIR__ . '/config',
-        __DIR__ . '/src',
-        __DIR__ . '/config',
-        __DIR__ . '/tests',
-    ]);
-
-    $rectorConfig->importNames();
-
-    $rectorConfig->bootstrapFiles([__DIR__ . '/tests/bootstrap.php']);
-
-    $rectorConfig->skip([
+return RectorConfig::configure()
+    ->withPhpSets(php82: true)
+    ->withPreparedSets(
+        codeQuality: true,
+        deadCode: true,
+        codingStyle: true,
+        typeDeclarations: true,
+        naming: true,
+        privatization: true,
+        earlyReturn: true
+    )
+    ->withPaths([__DIR__ . '/config', __DIR__ . '/src', __DIR__ . '/config', __DIR__ . '/tests'])
+    ->withRootFiles()
+    ->withImportNames()
+    ->withBootstrapFiles([__DIR__ . '/tests/bootstrap.php'])
+    ->withSkip([
         '*/Source/*',
         '*/Fixture/*',
         __DIR__ . '/src/SniffRunner/ValueObject/File.php',
 
         RenameParamToMatchTypeRector::class => [__DIR__ . '/src/FixerRunner/Application/FixerFileProcessor.php'],
     ]);
-};

--- a/scoper.php
+++ b/scoper.php
@@ -1,9 +1,9 @@
 <?php
 
 declare(strict_types=1);
+
 use Isolated\Symfony\Component\Finder\Finder;
 use Nette\Utils\Strings;
-use PHPUnit\Framework\TestCase;
 
 require __DIR__ . '/vendor/autoload.php';
 
@@ -108,7 +108,7 @@ return [
         },
 
         // fixes https://github.com/symplify/symplify/issues/3205
-        static function (string $filePath, string $prefix, string $content): string {
+        function (string $filePath, string $prefix, string $content): string {
             if (
                 ! str_ends_with($filePath, 'src/Testing/PHPUnit/AbstractCheckerTestCase.php') &&
                 ! str_ends_with($filePath, 'src/Testing/PHPUnit/AbstractTestCase.php')
@@ -119,17 +119,18 @@ return [
             return Strings::replace(
                 $content,
                 '#' . $prefix . '\\\\PHPUnit\\\\Framework\\\\TestCase#',
-                TestCase::class
+                'PHPUnit\Framework\TestCase'
             );
         },
 
         // add static versions constant values
-        static function (string $filePath, string $prefix, string $content): string {
+        function (string $filePath, string $prefix, string $content): string {
             if (! str_ends_with($filePath, 'src/Application/Version/StaticVersionResolver.php')) {
                 return $content;
             }
 
             $releaseDateTime = StaticVersionResolver::resolverReleaseDateTime();
+
             return strtr($content, [
                 '@package_version@' => StaticVersionResolver::resolvePackageVersion(),
                 '@release_date@' => $releaseDateTime->format('Y-m-d H:i:s'),

--- a/scoper.php
+++ b/scoper.php
@@ -115,6 +115,7 @@ return [
             ) {
                 return $content;
             }
+
             return Strings::replace(
                 $content,
                 '#' . $prefix . '\\\\PHPUnit\\\\Framework\\\\TestCase#',
@@ -127,6 +128,7 @@ return [
             if (! str_ends_with($filePath, 'src/Application/Version/StaticVersionResolver.php')) {
                 return $content;
             }
+
             $releaseDateTime = StaticVersionResolver::resolverReleaseDateTime();
             return strtr($content, [
                 '@package_version@' => StaticVersionResolver::resolvePackageVersion(),

--- a/scoper.php
+++ b/scoper.php
@@ -1,9 +1,9 @@
 <?php
 
 declare(strict_types=1);
-
 use Isolated\Symfony\Component\Finder\Finder;
 use Nette\Utils\Strings;
+use PHPUnit\Framework\TestCase;
 
 require __DIR__ . '/vendor/autoload.php';
 
@@ -108,29 +108,26 @@ return [
         },
 
         // fixes https://github.com/symplify/symplify/issues/3205
-        function (string $filePath, string $prefix, string $content): string {
+        static function (string $filePath, string $prefix, string $content): string {
             if (
                 ! str_ends_with($filePath, 'src/Testing/PHPUnit/AbstractCheckerTestCase.php') &&
                 ! str_ends_with($filePath, 'src/Testing/PHPUnit/AbstractTestCase.php')
             ) {
                 return $content;
             }
-
             return Strings::replace(
                 $content,
                 '#' . $prefix . '\\\\PHPUnit\\\\Framework\\\\TestCase#',
-                'PHPUnit\Framework\TestCase'
+                TestCase::class
             );
         },
 
         // add static versions constant values
-        function (string $filePath, string $prefix, string $content): string {
+        static function (string $filePath, string $prefix, string $content): string {
             if (! str_ends_with($filePath, 'src/Application/Version/StaticVersionResolver.php')) {
                 return $content;
             }
-
             $releaseDateTime = StaticVersionResolver::resolverReleaseDateTime();
-
             return strtr($content, [
                 '@package_version@' => StaticVersionResolver::resolvePackageVersion(),
                 '@release_date@' => $releaseDateTime->format('Y-m-d H:i:s'),


### PR DESCRIPTION
This repo seems still using old Rector 0.9

https://github.com/easy-coding-standard/easy-coding-standard/blob/bab49540ddd7a6550f5bd67fd96e250d1aa961ee/composer.json#L35

This PR bump to Rector ^1.0