### PR TITLE
Update Composer Linting Scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,9 +70,9 @@
             "@fix-rector",
             "@fix-cs"
         ],
-        "phpstan": "vendor/bin/phpstan analyse --ansi  --error-format symplify",
-        "rector": "vendor/bin/rector process --dry-run --ansi",
-        "fix-rector": "vendor/bin/rector process --ansi",
+        "phpstan": "vendor/bin/phpstan analyse --ansi --memory-limit=1G --error-format symplify",
+        "rector": "vendor/bin/rector process --dry-run --memory-limit=1G --ansi",
+        "fix-rector": "vendor/bin/rector process --memory-limit=1G --ansi",
         "check-cs": "bin/ecs check --ansi",
         "fix-cs": "bin/ecs check --fix --ansi"
     },

--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,18 @@
         }
     },
     "scripts": {
+        "lint": [
+            "@phpstan",
+            "@rector",
+            "@check-cs"
+        ],
+        "lint.fix": [
+            "@fix-rector",
+            "@fix-cs"
+        ],
         "phpstan": "vendor/bin/phpstan analyse --ansi  --error-format symplify",
         "rector": "vendor/bin/rector process --dry-run --ansi",
+        "fix-rector": "vendor/bin/rector process --ansi",
         "check-cs": "bin/ecs check --ansi",
         "fix-cs": "bin/ecs check --fix --ansi"
     },


### PR DESCRIPTION
Just a simple PR, aimed at contributor QoL. This adds `lint` and `lint.fix` composer scripts, allowing contributors to run all lint checks (and fixers) in one command without having to look it up.

I've also upped the memory limit of PhpStan being used to 1G (from the 128M default). I needed to manually use these flags for the first cache-less run or I would receive an out-of-memory error.