### PR TITLE
Add Support for PHPCS Standards / Rulesets and Related Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Install on **any PHP 7.2-PHP 8.3** project with any dependencies
 - Blazing fast with parallel run out of the box
 - Use [PHP_CodeSniffer or PHP-CS-Fixer](https://tomasvotruba.com/blog/2017/05/03/combine-power-of-php-code-sniffer-and-php-cs-fixer-in-3-lines/) - anything you like
-- Use **prepared sets** and [PHP CS Fixer sets](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/index.rst) to save time
+- Use **prepared sets**, [PHP CS Fixer sets](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/index.rst), or [PHP Code Sniffer standards](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage#specifying-a-coding-standard) to save time
 
 <br>
 
@@ -50,6 +50,7 @@ That's it!
 Most of the time, you'll be happy with the default configuration. The most relevant part is configuring paths, checkers and sets:
 
 ```php
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
@@ -58,6 +59,9 @@ return ECSConfig::configure()
     ->withRules([
         ArraySyntaxFixer::class,
     ])
+    // Warnings for included PHPCS rules are disabled by default,
+    // but they can be enabled manually.
+    ->withWarnings()
     ->withPreparedSets(psr12: true);
 ```
 
@@ -86,6 +90,52 @@ return ECSConfig::configure()
     ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
     ->withPhpCsFixerSets(perCS20: true, doctrineAnnotation: true);
 ```
+
+<br>
+
+Do you want to use [an existing PHPCS config or standard](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage#specifying-a-coding-standard)?
+You have plenty of options:
+
+```php
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return ECSConfig::configure()
+    ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
+
+    // Load your existing [.]phpcs.xml[.dist]
+    ->withSnifferStandards()
+
+    // Use any of their 8 built-ins.
+    ->withSnifferStandards(psr12: true)
+
+    // Maybe third parties interest you?
+    ->withSnifferStandards(vendor: 'WordPress')
+
+    // Or maybe you use LOTS of configs?
+    ->withSnifferStandards(
+        config: [ 'phpcs.xml.dist', 'phpcs.xml' ],
+        vendor: [ 'WordPress', 'PHPCompatibility' ],
+        psr12: true
+    )
+
+    // The standards warning severities are respected by default,
+    // this returns to the default behavior of skipping most warnings.
+    ->withSnifferStandards(withWarnings: false);
+```
+
+> [!IMPORTANT]
+> This only supports a **subset** of PHPCS configuration:
+>
+> - Included rules and their default configurations.
+> - Rules excluded globally or based on patterns.
+> - Severity levels.
+> - Ruleset inheritance.
+>
+> Rules included only for specific paths will be included globally instead.
+> To migrate, enable these rules globally and specify _excluded_ paths instead.
+>
+> All other arguments, parameters, or settings are ignored.
+> This includes specified file patterns and extensions.
 
 <br>
 
@@ -201,6 +251,17 @@ Do you look for json format?
 
 ```bash
 vendor/bin/ecs list-checkers --output-format json
+```
+
+### ECS isn't respecting my `phpcs:ignore` directives?
+
+Currently, we do not support comment-based directives to enable, disable, or
+ignore specific rules or specific tools. We do support our own global toggle:
+
+```php
+// @codingStandardsIgnoreStart
+$atom = "[-a-z0-9!#$%&'*+/=?^_`{|}~]"; // RFC 5322 unquoted characters in local-part
+// @codingStandardsIgnoreEnd
 ```
 
 <br>

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
             "@fix-rector",
             "@fix-cs"
         ],
+        "test": "phpunit",
         "phpstan": "vendor/bin/phpstan analyse --ansi --memory-limit=1G --error-format symplify",
         "rector": "vendor/bin/rector process --dry-run --memory-limit=1G --ansi",
         "fix-rector": "vendor/bin/rector process --memory-limit=1G --ansi",

--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -33,6 +33,11 @@ final class ECSConfigBuilder
     private array $dynamicSets = [];
 
     /**
+     * @var string[]|null
+     */
+    private ?array $snifferStandards = null;
+
+    /**
      * @var array<mixed>
      */
     private array $skip = [];
@@ -71,6 +76,8 @@ final class ECSConfigBuilder
 
     private int $parallelJobSize = 20;
 
+    private bool $areWarningsEnabled = false;
+
     public function __invoke(ECSConfig $ecsConfig): void
     {
         if ($this->sets !== []) {
@@ -79,6 +86,10 @@ final class ECSConfigBuilder
 
         if ($this->dynamicSets !== []) {
             $ecsConfig->dynamicSets($this->dynamicSets);
+        }
+
+        if ($this->snifferStandards !== null) {
+            $ecsConfig->snifferStandards($this->snifferStandards);
         }
 
         if ($this->paths !== []) {
@@ -128,6 +139,8 @@ final class ECSConfigBuilder
                 $ecsConfig->disableParallel();
             }
         }
+
+        $ecsConfig->setWarnings($this->areWarningsEnabled);
     }
 
     /**
@@ -175,7 +188,6 @@ final class ECSConfigBuilder
         bool $common = false,
         /** @see SetList::SYMPLIFY */
         bool $symplify = false,
-
         // common sets
         /** @see SetList::ARRAY */
         bool $arrays = false,
@@ -490,6 +502,71 @@ final class ECSConfigBuilder
     }
 
     /**
+     * @param string|string[] $config
+     * @param string|string[] $vendor
+     */
+    public function withSnifferStandards(
+        mixed $config = null,
+        mixed $vendor = null,
+        bool $mySource = false,
+        bool $pear = false,
+        bool $psr1 = false,
+        bool $psr2 = false,
+        bool $psr12 = false,
+        bool $squiz = false,
+        bool $zend = false,
+        bool $withWarnings = true
+    ): self {
+        $this->snifferStandards = [];
+
+        if ($config !== null) {
+            if (is_array($config)) {
+                $this->snifferStandards = array_merge($this->snifferStandards, $config);
+            } else {
+                $this->snifferStandards[] = $config;
+            }
+        }
+
+        if ($vendor !== null) {
+            if (is_array($vendor)) {
+                $this->snifferStandards = array_merge($this->snifferStandards, $vendor);
+            } else {
+                $this->snifferStandards[] = $vendor;
+            }
+        }
+
+        if ($mySource) {
+            $this->snifferStandards[] = 'MySource';
+        }
+
+        if ($pear) {
+            $this->snifferStandards[] = 'PEAR';
+        }
+
+        if ($psr1) {
+            $this->snifferStandards[] = 'PSR1';
+        }
+
+        if ($psr2) {
+            $this->snifferStandards[] = 'PSR2';
+        }
+
+        if ($psr12) {
+            $this->snifferStandards[] = 'PSR12';
+        }
+
+        if ($squiz) {
+            $this->snifferStandards[] = 'Squiz';
+        }
+
+        if ($zend) {
+            $this->snifferStandards[] = 'Zend';
+        }
+
+        return $this->withWarnings($withWarnings);
+    }
+
+    /**
      * @param string[] $sets
      */
     public function withSets(array $sets): self
@@ -575,6 +652,18 @@ final class ECSConfigBuilder
     {
         $this->parallel = false;
 
+        return $this;
+    }
+
+    public function withWarnings(bool $areEnabled = true): self
+    {
+        $this->areWarningsEnabled = $areEnabled;
+        return $this;
+    }
+
+    public function withoutWarnings(): self
+    {
+        $this->areWarningsEnabled = false;
         return $this;
     }
 }

--- a/src/DependencyInjection/LazyContainerFactory.php
+++ b/src/DependencyInjection/LazyContainerFactory.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Symplify\EasyCodingStandard\DependencyInjection;
 
 use Illuminate\Container\Container;
+use PHP_CodeSniffer\Config as SnifferConfig;
 use PHP_CodeSniffer\Fixer;
+use PHP_CodeSniffer\Ruleset as SnifferRuleset;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Util\Tokens;
 use PhpCsFixer\Differ\DifferInterface;
@@ -109,6 +111,18 @@ final class LazyContainerFactory
         $ecsConfig->when(SniffFileProcessor::class)
             ->needs('$sniffs')
             ->giveTagged(Sniff::class);
+
+        $ecsConfig->singleton(SnifferRuleset::class, static fn (): null => null);
+        $ecsConfig->singleton(
+            SnifferConfig::class,
+            static fn (): SnifferConfig => new SnifferConfig([
+                '--error-severity=1',
+                '--warning-severity=0',
+                '--tab-width=4',
+                '--ignore-annotations',
+                '--encoding=UTF-8',
+            ])
+        );
 
         // load default config first
         $configFiles = [__DIR__ . '/../../config/config.php', ...$configFiles];

--- a/src/SniffRunner/Application/SniffFileProcessor.php
+++ b/src/SniffRunner/Application/SniffFileProcessor.php
@@ -148,14 +148,14 @@ final class SniffFileProcessor implements FileProcessorInterface
      * @see \PHP_CodeSniffer\Fixer::fixFile()
      *
      * @param array<int|string, Sniff[]> $tokenListeners
-     * @param array<class-string<Sniff>> $reportSniffClassesWarnings
+     * @param array<class-string<Sniff>> $escalatedSniffClassesWarnings
      */
     private function fixFile(
         File $file,
         Fixer $fixer,
         string $filePath,
         array $tokenListeners,
-        array $reportSniffClassesWarnings
+        array $escalatedSniffClassesWarnings
     ): void {
         $previousContent = FileSystem::read($filePath);
 
@@ -169,7 +169,7 @@ final class SniffFileProcessor implements FileProcessorInterface
             PrivatesAccessorHelper::setPropertyValue($fixer, 'inConflict', false);
 
             $file->setContent($content);
-            $file->processWithTokenListenersAndFilePath($tokenListeners, $filePath, $reportSniffClassesWarnings);
+            $file->processWithTokenListenersAndFilePath($tokenListeners, $filePath, $escalatedSniffClassesWarnings);
 
             // fixed content
             $previousContent = $fixer->getContents();

--- a/src/SniffRunner/DataCollector/SniffMetadataCollector.php
+++ b/src/SniffRunner/DataCollector/SniffMetadataCollector.php
@@ -41,6 +41,11 @@ final class SniffMetadataCollector
         $this->codingStandardErrors = [];
     }
 
+    public function resetErrors(): void
+    {
+        $this->codingStandardErrors = [];
+    }
+
     public function addCodingStandardError(CodingStandardError $codingStandardError): void
     {
         $this->codingStandardErrors[] = $codingStandardError;

--- a/src/SniffRunner/File/FileFactory.php
+++ b/src/SniffRunner/File/FileFactory.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Symplify\EasyCodingStandard\SniffRunner\File;
 
 use Nette\Utils\FileSystem;
+use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Fixer;
+use PHP_CodeSniffer\Ruleset;
 use Symplify\EasyCodingStandard\Console\Style\EasyCodingStandardStyle;
 use Symplify\EasyCodingStandard\FileSystem\StaticRelativeFilePathHelper;
 use Symplify\EasyCodingStandard\Skipper\Skipper\Skipper;
@@ -21,7 +23,9 @@ final readonly class FileFactory
         private Fixer $fixer,
         private Skipper $skipper,
         private SniffMetadataCollector $sniffMetadataCollector,
-        private EasyCodingStandardStyle $easyCodingStandardStyle
+        private EasyCodingStandardStyle $easyCodingStandardStyle,
+        private Config $config,
+        private ?Ruleset $ruleset,
     ) {
     }
 
@@ -36,7 +40,9 @@ final readonly class FileFactory
             $this->fixer,
             $this->skipper,
             $this->sniffMetadataCollector,
-            $this->easyCodingStandardStyle
+            $this->easyCodingStandardStyle,
+            $this->config,
+            $this->ruleset,
         );
     }
 }

--- a/src/SniffRunner/ValueObject/File.php
+++ b/src/SniffRunner/ValueObject/File.php
@@ -76,6 +76,10 @@ final class File extends BaseFile
      */
     public function process(): void
     {
+        // Since sniffs are re-run after they do fixes, we need to clear the old
+        // errors to avoid duplicates.
+        $this->sniffMetadataCollector->resetErrors();
+
         $this->parse();
         $this->fixer->startFile($this);
 


### PR DESCRIPTION
**Parent Tickets:**

- #30 
- #128 
- #214 
- #215 

This gives us improved support for PHPCS Sniffs by allowing users to import either the built-in standards or rulesets provided by themselves or third parties, then adjusting how we handle sniffs to more closely match PHPCS itself. The changes required for this are quite involved, so I recommend checking out the commit messages themselves, where I've already gone into detail on the "why" for most of these changes.

Some existing issues were identified during my self-testing, one of which was already reported, and I've made sure to fix them.

I'm leaving this PR as a draft for now, since I still need to write tests to cover the new configuration options. However, in it's current state I *have* made sure it passes all linting and then manually tested it (against itself, comparing to direct PHPCS output) for:

- The built-in PHPCS PSR12 standard.
- A customized `phpcs.xml.dist`.
- Config cache invalidation behavior.

*The changes / configs for the above testing were not committed.*

It ran well and matched what PHPCS itself reported, so everything *should* be fine.