### PR TITLE
Add withRealPathReporting() to allow real paths in output formatters - ref #219

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -22,4 +22,6 @@ return ECSConfig::configure()
     ->withCache(directory: $cacheDirectory, namespace: $cacheNamespace)
     ->withFileExtensions(['php'])
     ->withSkip([])
-    ->withPaths([]);
+    ->withPaths([])
+    ->withRealPathReporting(false)
+;

--- a/src/Config/ECSConfig.php
+++ b/src/Config/ECSConfig.php
@@ -189,6 +189,14 @@ final class ECSConfig extends Container
     }
 
     /**
+     * @api
+     */
+    public function reportingRealPath(bool $absolute = true): void
+    {
+        SimpleParameterProvider::setParameter(Option::REPORTING_REALPATH, $absolute);
+    }
+
+    /**
      * @link https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/index.rst
      * @param list<string> $setNames
      */

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -40,6 +40,8 @@ final readonly class ConfigurationFactory
 
         $isParallel = SimpleParameterProvider::getBoolParameter(Option::PARALLEL);
 
+        $isReportingWithRealPath = SimpleParameterProvider::getBoolParameter(Option::REPORTING_REALPATH);
+
         $config = $input->getOption(Option::CONFIG);
         if ($config !== null) {
             $config = (string) $config;
@@ -57,7 +59,8 @@ final readonly class ConfigurationFactory
             $parallelPort,
             $parallelIdentifier,
             $memoryLimit,
-            $showDiffs
+            $showDiffs,
+            $isReportingWithRealPath
         );
     }
 

--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -131,7 +131,9 @@ final class ECSConfigBuilder
             }
         }
 
-        $ecsConfig->reportingRealPath($this->reportingRealPath === null ? false : $this->reportingRealPath);
+        if ($this->reportingRealPath !== null) {
+            $ecsConfig->reportingRealPath($this->reportingRealPath);
+        }
     }
 
     /**

--- a/src/Configuration/ECSConfigBuilder.php
+++ b/src/Configuration/ECSConfigBuilder.php
@@ -71,6 +71,8 @@ final class ECSConfigBuilder
 
     private int $parallelJobSize = 20;
 
+    private ?bool $reportingRealPath = null;
+
     public function __invoke(ECSConfig $ecsConfig): void
     {
         if ($this->sets !== []) {
@@ -128,6 +130,8 @@ final class ECSConfigBuilder
                 $ecsConfig->disableParallel();
             }
         }
+
+        $ecsConfig->reportingRealPath($this->reportingRealPath === null ? false : $this->reportingRealPath);
     }
 
     /**
@@ -574,6 +578,13 @@ final class ECSConfigBuilder
     public function withoutParallel(): self
     {
         $this->parallel = false;
+
+        return $this;
+    }
+
+    public function withRealPathReporting(bool $absolutePath = true): self
+    {
+        $this->reportingRealPath = $absolutePath;
 
         return $this;
     }

--- a/src/Console/Output/CheckstyleOutputFormatter.php
+++ b/src/Console/Output/CheckstyleOutputFormatter.php
@@ -29,7 +29,10 @@ final readonly class CheckstyleOutputFormatter implements OutputFormatterInterfa
      */
     public function report(ErrorAndDiffResult $errorAndDiffResult, Configuration $configuration): int
     {
-        $checkstyleContent = $this->createCheckstyleContent($errorAndDiffResult, $configuration->isReportingWithRealPath());
+        $checkstyleContent = $this->createCheckstyleContent(
+            $errorAndDiffResult,
+            $configuration->isReportingWithRealPath()
+        );
         $this->easyCodingStandardStyle->writeln($checkstyleContent);
 
         return $this->exitCodeResolver->resolve($errorAndDiffResult, $configuration);
@@ -48,8 +51,10 @@ final readonly class CheckstyleOutputFormatter implements OutputFormatterInterfa
     /**
      * @api
      */
-    public function createCheckstyleContent(ErrorAndDiffResult $errorAndDiffResult, bool $absoluteFilePath = false): string
-    {
+    public function createCheckstyleContent(
+        ErrorAndDiffResult $errorAndDiffResult,
+        bool $absoluteFilePath = false
+    ): string {
         if (! \extension_loaded('dom')) {
             throw new RuntimeException('Cannot generate report! `ext-dom` is not available!');
         }

--- a/src/Console/Output/CheckstyleOutputFormatter.php
+++ b/src/Console/Output/CheckstyleOutputFormatter.php
@@ -29,7 +29,7 @@ final readonly class CheckstyleOutputFormatter implements OutputFormatterInterfa
      */
     public function report(ErrorAndDiffResult $errorAndDiffResult, Configuration $configuration): int
     {
-        $checkstyleContent = $this->createCheckstyleContent($errorAndDiffResult);
+        $checkstyleContent = $this->createCheckstyleContent($errorAndDiffResult, $configuration->isReportingWithRealPath());
         $this->easyCodingStandardStyle->writeln($checkstyleContent);
 
         return $this->exitCodeResolver->resolve($errorAndDiffResult, $configuration);
@@ -48,7 +48,7 @@ final readonly class CheckstyleOutputFormatter implements OutputFormatterInterfa
     /**
      * @api
      */
-    public function createCheckstyleContent(ErrorAndDiffResult $errorAndDiffResult): string
+    public function createCheckstyleContent(ErrorAndDiffResult $errorAndDiffResult, bool $absoluteFilePath = false): string
     {
         if (! \extension_loaded('dom')) {
             throw new RuntimeException('Cannot generate report! `ext-dom` is not available!');
@@ -60,9 +60,10 @@ final readonly class CheckstyleOutputFormatter implements OutputFormatterInterfa
         $domNode = $domDocument->appendChild($domDocument->createElement('checkstyle'));
 
         foreach ($errorAndDiffResult->getFileDiffs() as $fileDiff) {
+            $filePath = $absoluteFilePath ? $fileDiff->getAbsoluteFilePath() : $fileDiff->getRelativeFilePath();
             /** @var DOMElement $file */
             $file = $domNode->appendChild($domDocument->createElement('file'));
-            $file->setAttribute('name', $fileDiff->getRelativeFilePath());
+            $file->setAttribute('name', $filePath ?? '');
 
             foreach ($fileDiff->getAppliedCheckers() as $appliedChecker) {
                 $errorElement = $this->createError($domDocument, $appliedChecker);

--- a/src/Console/Output/ConsoleOutputFormatter.php
+++ b/src/Console/Output/ConsoleOutputFormatter.php
@@ -31,7 +31,7 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
     public function report(ErrorAndDiffResult $errorAndDiffResult, Configuration $configuration): int
     {
         if ($configuration->shouldShowDiffs()) {
-            $this->reportFileDiffs($errorAndDiffResult->getFileDiffs());
+            $this->reportFileDiffs($errorAndDiffResult->getFileDiffs(), $configuration->isReportingWithRealPath());
         }
 
         $this->easyCodingStandardStyle->newLine(1);
@@ -66,7 +66,7 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
     /**
      * @param FileDiff[] $fileDiffs
      */
-    private function reportFileDiffs(array $fileDiffs): void
+    private function reportFileDiffs(array $fileDiffs, bool $absoluteFilePath = false): void
     {
         if ($fileDiffs === []) {
             return;
@@ -78,7 +78,8 @@ final readonly class ConsoleOutputFormatter implements OutputFormatterInterface
         foreach ($fileDiffs as $fileDiff) {
             $this->easyCodingStandardStyle->newLine(2);
 
-            $boldNumberedMessage = sprintf('<options=bold>%d) %s</>', $i, $fileDiff->getRelativeFilePath());
+            $filePath = $absoluteFilePath ? $fileDiff->getAbsoluteFilePath() : $fileDiff->getRelativeFilePath();
+            $boldNumberedMessage = sprintf('<options=bold>%d) %s</>', $i, $filePath);
             $this->easyCodingStandardStyle->writeln($boldNumberedMessage);
 
             ++$i;

--- a/src/Console/Output/GitlabOutputFormatter.php
+++ b/src/Console/Output/GitlabOutputFormatter.php
@@ -95,10 +95,10 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
     {
         $reportedQualityIssues = (! $configuration->isFixer() && $configuration->shouldShowDiffs())
             ? merge(
-                $this->generateIssuesForErrors($errorAndDiffResult->getErrors()),
-                $this->generateIssuesForFixes($errorAndDiffResult->getFileDiffs()),
+                $this->generateIssuesForErrors($errorAndDiffResult->getErrors(), $configuration->isReportingWithRealPath()),
+                $this->generateIssuesForFixes($errorAndDiffResult->getFileDiffs(), $configuration->isReportingWithRealPath()),
             )
-            : $this->generateIssuesForErrors($errorAndDiffResult->getErrors());
+            : $this->generateIssuesForErrors($errorAndDiffResult->getErrors(), $configuration->isReportingWithRealPath());
 
         return $this->encode($reportedQualityIssues);
     }
@@ -107,7 +107,7 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
      * @param CodingStandardError[] $errors
      * @return GitlabIssue[]
      */
-    private function generateIssuesForErrors(array $errors): array
+    private function generateIssuesForErrors(array $errors, bool $absoluteFilePath = false): array
     {
         return map(
             fn (CodingStandardError $codingStandardError): array => [
@@ -122,7 +122,7 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
                 'severity' => 'minor',
                 'categories' => ['Style'],
                 'location' => [
-                    'path' => $codingStandardError->getRelativeFilePath(),
+                    'path' => $absoluteFilePath ? $codingStandardError->getAbsoluteFilePath() ?? '' : $codingStandardError->getRelativeFilePath(),
                     'lines' => [
                         'begin' => $codingStandardError->getLine(),
                         'end' => $codingStandardError->getLine(),
@@ -139,12 +139,12 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
      * @param FileDiff[] $diffs
      * @return GitlabIssue[]
      */
-    private function generateIssuesForFixes(array $diffs): array
+    private function generateIssuesForFixes(array $diffs, bool $absoluteFilePath = false): array
     {
         return merge(
             ...map(
                 fn (FileDiff $fileDiff): array => map(
-                    fn (Chunk $chunk): array => $this->generateIssueForChunk($fileDiff, $chunk),
+                    fn (Chunk $chunk): array => $this->generateIssueForChunk($fileDiff, $chunk, $absoluteFilePath),
                     $this->diffParser->parse($fileDiff->getDiff())[0]->chunks(),
                 ),
                 $diffs,
@@ -155,7 +155,7 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
     /**
      * @return GitlabIssue
      */
-    private function generateIssueForChunk(FileDiff $fileDiff, Chunk $chunk): array
+    private function generateIssueForChunk(FileDiff $fileDiff, Chunk $chunk, bool $absoluteFilePath): array
     {
         $checkersAsFqcns = implode(',', $fileDiff->getAppliedCheckers());
         $checkersAsClasses = implode(', ', map(
@@ -188,7 +188,7 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
             'categories' => ['Style'],
             'remediation_points' => 50_000,
             'location' => [
-                'path' => $fileDiff->getRelativeFilePath(),
+                'path' => $absoluteFilePath ? $fileDiff->getAbsoluteFilePath() ?? '' : $fileDiff->getRelativeFilePath(),
                 'lines' => [
                     'begin' => $lineStart,
                     'end' => $lineEnd,

--- a/src/Console/Output/GitlabOutputFormatter.php
+++ b/src/Console/Output/GitlabOutputFormatter.php
@@ -95,10 +95,19 @@ final readonly class GitlabOutputFormatter implements OutputFormatterInterface
     {
         $reportedQualityIssues = (! $configuration->isFixer() && $configuration->shouldShowDiffs())
             ? merge(
-                $this->generateIssuesForErrors($errorAndDiffResult->getErrors(), $configuration->isReportingWithRealPath()),
-                $this->generateIssuesForFixes($errorAndDiffResult->getFileDiffs(), $configuration->isReportingWithRealPath()),
+                $this->generateIssuesForErrors(
+                    $errorAndDiffResult->getErrors(),
+                    $configuration->isReportingWithRealPath()
+                ),
+                $this->generateIssuesForFixes(
+                    $errorAndDiffResult->getFileDiffs(),
+                    $configuration->isReportingWithRealPath()
+                ),
             )
-            : $this->generateIssuesForErrors($errorAndDiffResult->getErrors(), $configuration->isReportingWithRealPath());
+            : $this->generateIssuesForErrors(
+                $errorAndDiffResult->getErrors(),
+                $configuration->isReportingWithRealPath()
+            );
 
         return $this->encode($reportedQualityIssues);
     }

--- a/src/Console/Output/JUnitOutputFormatter.php
+++ b/src/Console/Output/JUnitOutputFormatter.php
@@ -27,7 +27,7 @@ final readonly class JUnitOutputFormatter implements OutputFormatterInterface
      */
     public function report(ErrorAndDiffResult $errorAndDiffResult, Configuration $configuration): int
     {
-        $xml = $this->createXmlOutput($errorAndDiffResult);
+        $xml = $this->createXmlOutput($errorAndDiffResult, $configuration->isReportingWithRealPath());
         $this->easyCodingStandardStyle->writeln($xml);
 
         return $this->exitCodeResolver->resolve($errorAndDiffResult, $configuration);
@@ -46,7 +46,7 @@ final readonly class JUnitOutputFormatter implements OutputFormatterInterface
     /**
      * @api
      */
-    public function createXmlOutput(ErrorAndDiffResult $errorAndDiffResult): string
+    public function createXmlOutput(ErrorAndDiffResult $errorAndDiffResult, bool $absoluteFilePath = false): string
     {
         $result = '<?xml version="1.0" encoding="UTF-8"?>';
 
@@ -60,7 +60,7 @@ final readonly class JUnitOutputFormatter implements OutputFormatterInterface
         );
 
         foreach ($errorAndDiffResult->getErrors() as $codingStandardError) {
-            $fileName = $codingStandardError->getRelativeFilePath();
+            $fileName = $absoluteFilePath ? $codingStandardError->getAbsoluteFilePath() : $codingStandardError->getRelativeFilePath();
             $result .= $this->createTestCase(
                 sprintf('%s:%s', $fileName, $codingStandardError->getLine()),
                 $codingStandardError->getMessage()
@@ -74,8 +74,8 @@ final readonly class JUnitOutputFormatter implements OutputFormatterInterface
         }
 
         foreach ($errorAndDiffResult->getFileDiffs() as $codingStandardError) {
-            $fileName = $codingStandardError->getRelativeFilePath();
-            $result .= $this->createTestCase($fileName, $codingStandardError->getDiff());
+            $fileName = $absoluteFilePath ? $codingStandardError->getAbsoluteFilePath() : $codingStandardError->getRelativeFilePath();
+            $result .= $this->createTestCase($fileName ?? '', $codingStandardError->getDiff());
         }
 
         return $result . '</testsuite>';

--- a/src/Parallel/ValueObject/Name.php
+++ b/src/Parallel/ValueObject/Name.php
@@ -32,6 +32,11 @@ final class Name
     /**
      * @var string
      */
+    public const ABSOLUTE_FILE_PATH = 'absolute_file_path';
+
+    /**
+     * @var string
+     */
     public const DIFF = 'diff';
 
     /**

--- a/src/SniffRunner/ValueObject/Error/CodingStandardError.php
+++ b/src/SniffRunner/ValueObject/Error/CodingStandardError.php
@@ -48,7 +48,7 @@ final readonly class CodingStandardError implements SerializableInterface
     }
 
     /**
-     * @return array{line: int, message: string, checker_class: string, relative_file_path: string}
+     * @return array{line: int, message: string, checker_class: string, absolute_file_path: string|null, relative_file_path: string}
      */
     public function jsonSerialize(): array
     {

--- a/src/SniffRunner/ValueObject/Error/CodingStandardError.php
+++ b/src/SniffRunner/ValueObject/Error/CodingStandardError.php
@@ -44,7 +44,7 @@ final readonly class CodingStandardError implements SerializableInterface
 
     public function getAbsoluteFilePath(): ?string
     {
-        return \realpath($this->relativeFilePath) ? : null;
+        return \realpath($this->relativeFilePath) ?: null;
     }
 
     /**

--- a/src/SniffRunner/ValueObject/Error/CodingStandardError.php
+++ b/src/SniffRunner/ValueObject/Error/CodingStandardError.php
@@ -42,6 +42,11 @@ final readonly class CodingStandardError implements SerializableInterface
         return $this->relativeFilePath;
     }
 
+    public function getAbsoluteFilePath(): ?string
+    {
+        return \realpath($this->relativeFilePath) ? : null;
+    }
+
     /**
      * @return array{line: int, message: string, checker_class: string, relative_file_path: string}
      */
@@ -51,6 +56,7 @@ final readonly class CodingStandardError implements SerializableInterface
             Name::LINE => $this->line,
             Name::MESSAGE => $this->message,
             Name::CHECKER_CLASS => $this->checkerClass,
+            Name::ABSOLUTE_FILE_PATH => $this->getAbsoluteFilePath(),
             Name::RELATIVE_FILE_PATH => $this->relativeFilePath,
         ];
     }

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -23,7 +23,8 @@ final readonly class Configuration
         private string | null $parallelPort = null,
         private string | null $parallelIdentifier = null,
         private string | null $memoryLimit = null,
-        private bool $showDiffs = true
+        private bool $showDiffs = true,
+        private bool $reportingWithRealPath = false
     ) {
     }
 
@@ -88,5 +89,10 @@ final readonly class Configuration
     public function getMemoryLimit(): ?string
     {
         return $this->memoryLimit;
+    }
+
+    public function isReportingWithRealPath(): bool
+    {
+        return $this->reportingWithRealPath;
     }
 }

--- a/src/ValueObject/Error/FileDiff.php
+++ b/src/ValueObject/Error/FileDiff.php
@@ -50,7 +50,7 @@ final class FileDiff implements SerializableInterface
 
     public function getAbsoluteFilePath(): ?string
     {
-        return \realpath($this->relativeFilePath) ? : null;
+        return \realpath($this->relativeFilePath) ?: null;
     }
 
     /**

--- a/src/ValueObject/Error/FileDiff.php
+++ b/src/ValueObject/Error/FileDiff.php
@@ -48,12 +48,18 @@ final class FileDiff implements SerializableInterface
         return $this->relativeFilePath;
     }
 
+    public function getAbsoluteFilePath(): ?string
+    {
+        return \realpath($this->relativeFilePath) ? : null;
+    }
+
     /**
      * @return array{relative_file_path: string, diff: string, diff_console_formatted: string, applied_checkers: string[]}
      */
     public function jsonSerialize(): array
     {
         return [
+            Name::ABSOLUTE_FILE_PATH => $this->getAbsoluteFilePath(),
             Name::RELATIVE_FILE_PATH => $this->relativeFilePath,
             Name::DIFF => $this->diff,
             Name::DIFF_CONSOLE_FORMATTED => $this->consoleFormattedDiff,

--- a/src/ValueObject/Option.php
+++ b/src/ValueObject/Option.php
@@ -154,4 +154,10 @@ final class Option
      * @var string
      */
     public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';
+
+    /**
+     * @see \Symplify\EasyCodingStandard\Config\ECSConfig::reportingRealPath()
+     * @var string
+     */
+    public const REPORTING_REALPATH = 'reporting-realpath';
 }


### PR DESCRIPTION
Solved conflicts found with previous PR 220 and 221

Locally after running QA tools I got : 

![qa](https://github.com/easy-coding-standard/easy-coding-standard/assets/364342/6869328f-a2fb-4f25-b08a-857dd622f58e)

And after running tests on all formatters (`gitlab`, `checkstyle`, `json`, `junit`, `console`) with option  `--output-format` I got expected results
when activate or not the real path reporting option. 