### PR TITLE
Remove nette/utils dependency

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -40,6 +40,10 @@ jobs:
                         name: 'Check Active Classes'
                         run: vendor/bin/class-leak check bin src --ansi
 
+                    -
+                        name: 'Detect composer dependency issues'
+                        run: vendor/bin/composer-dependency-analyser
+
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "composer/xdebug-handler": "^3.0",
         "friendsofphp/php-cs-fixer": "^3.59.3",
         "illuminate/container": "^10.39",
-        "nette/utils": "^3.2",
         "sebastian/diff": "^5.1",
         "squizlabs/php_codesniffer": "^3.10.1",
         "symfony/console": "^6.4",

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "phpstan/phpstan-webmozart-assert": "^1.2",
         "phpunit/phpunit": "^10.5",
         "rector/rector": "^1.0",
+        "shipmonk/composer-dependency-analyser": "^1.6",
         "symplify/phpstan-extensions": "^11.4",
         "symplify/vendor-patches": "^11.3",
         "tomasvotruba/class-leak": "^0.2",


### PR DESCRIPTION
symplify/coding-standard already require it

https://github.com/symplify/coding-standard/blob/2a261fe788e8c1e6f216490121b6942d8f7e313c/composer.json#L7

Upgrading to v4 needs from there