### PR TITLE
Allow PHPCS Sniffs to Disable Themselves

### DIFF
--- a/src/SniffRunner/ValueObject/File.php
+++ b/src/SniffRunner/ValueObject/File.php
@@ -66,7 +66,7 @@ final class File extends BaseFile
         $this->eolChar = Common::detectLineEndings($content);
 
         // compat
-        if (! defined('PHP_CODESNIFFER_CBF')) {
+        if (!defined('PHP_CODESNIFFER_CBF')) {
             define('PHP_CODESNIFFER_CBF', false);
         }
 
@@ -87,12 +87,12 @@ final class File extends BaseFile
         $this->fixer->startFile($this);
 
         $currentFilePath = $this->filePath;
-        if (! is_string($currentFilePath)) {
+        if (!is_string($currentFilePath)) {
             throw new ShouldNotHappenException();
         }
 
         foreach ($this->tokens as $stackPtr => $token) {
-            if (! isset($this->tokenListeners[$token['code']])) {
+            if (!isset($this->tokenListeners[$token['code']])) {
                 continue;
             }
 
@@ -123,7 +123,7 @@ final class File extends BaseFile
         $fullyQualifiedCode = $this->resolveFullyQualifiedCode($code);
         $this->sniffMetadataCollector->addAppliedSniff($fullyQualifiedCode);
 
-        return ! $this->shouldSkipError($error, $code, $data);
+        return !$this->shouldSkipError($error, $code, $data);
     }
 
     /**
@@ -185,7 +185,7 @@ final class File extends BaseFile
         $isFixable = false
     ): bool {
         // skip warnings
-        if (! $isError) {
+        if (!$isError) {
             return false;
         }
 
@@ -215,7 +215,7 @@ final class File extends BaseFile
         // used in other places later
         $this->activeSniffClass = $sniff::class;
 
-        if (! $this->easyCodingStandardStyle->isDebug()) {
+        if (!$this->easyCodingStandardStyle->isDebug()) {
             return;
         }
 
@@ -243,7 +243,7 @@ final class File extends BaseFile
     {
         $fullyQualifiedCode = $this->resolveFullyQualifiedCode($code);
 
-        if (! is_string($this->filePath)) {
+        if (!is_string($this->filePath)) {
             throw new ShouldNotHappenException();
         }
 
@@ -276,8 +276,8 @@ final class File extends BaseFile
         }
 
         unset($this->disabledSniffers[$sniffClass]);
-                return false;
-            }
+        return false;
+    }
 
     /**
      * @param class-string<Sniff> $sniffClass
@@ -289,7 +289,5 @@ final class File extends BaseFile
         }
 
         $this->disabledSniffers[$sniffClass] = $targetStackPtr;
-    }
-        return true;
     }
 }

--- a/src/SniffRunner/ValueObject/File.php
+++ b/src/SniffRunner/ValueObject/File.php
@@ -66,7 +66,7 @@ final class File extends BaseFile
         $this->eolChar = Common::detectLineEndings($content);
 
         // compat
-        if (!defined('PHP_CODESNIFFER_CBF')) {
+        if (! defined('PHP_CODESNIFFER_CBF')) {
             define('PHP_CODESNIFFER_CBF', false);
         }
 
@@ -87,12 +87,12 @@ final class File extends BaseFile
         $this->fixer->startFile($this);
 
         $currentFilePath = $this->filePath;
-        if (!is_string($currentFilePath)) {
+        if (! is_string($currentFilePath)) {
             throw new ShouldNotHappenException();
         }
 
         foreach ($this->tokens as $stackPtr => $token) {
-            if (!isset($this->tokenListeners[$token['code']])) {
+            if (! isset($this->tokenListeners[$token['code']])) {
                 continue;
             }
 
@@ -123,7 +123,7 @@ final class File extends BaseFile
         $fullyQualifiedCode = $this->resolveFullyQualifiedCode($code);
         $this->sniffMetadataCollector->addAppliedSniff($fullyQualifiedCode);
 
-        return !$this->shouldSkipError($error, $code, $data);
+        return ! $this->shouldSkipError($error, $code, $data);
     }
 
     /**
@@ -185,7 +185,7 @@ final class File extends BaseFile
         $isFixable = false
     ): bool {
         // skip warnings
-        if (!$isError) {
+        if (! $isError) {
             return false;
         }
 
@@ -215,7 +215,7 @@ final class File extends BaseFile
         // used in other places later
         $this->activeSniffClass = $sniff::class;
 
-        if (!$this->easyCodingStandardStyle->isDebug()) {
+        if (! $this->easyCodingStandardStyle->isDebug()) {
             return;
         }
 
@@ -243,7 +243,7 @@ final class File extends BaseFile
     {
         $fullyQualifiedCode = $this->resolveFullyQualifiedCode($code);
 
-        if (!is_string($this->filePath)) {
+        if (! is_string($this->filePath)) {
             throw new ShouldNotHappenException();
         }
 

--- a/src/SniffRunner/ValueObject/File.php
+++ b/src/SniffRunner/ValueObject/File.php
@@ -38,6 +38,13 @@ final class File extends BaseFile
     private ?string $filePath = null;
 
     /**
+     * @var array<class-string<Sniff>, int> A map of which sniffers have
+     *     requested themselves to be disabled, pointing to the index in
+     *     the files token stack that they are to be re-enabled.
+     */
+    private array $disabledSniffers = [];
+
+    /**
      * @var array<class-string<Sniff>>
      */
     private array $reportSniffClassesWarnings = [];
@@ -90,17 +97,20 @@ final class File extends BaseFile
             }
 
             foreach ($this->tokenListeners[$token['code']] as $sniff) {
-                if ($this->skipper->shouldSkipElementAndFilePath($sniff, $currentFilePath)) {
+                $shouldSkipSniff = $this->skipper->shouldSkipElementAndFilePath($sniff, $currentFilePath);
+                $sniffIsDisabled = $this->isSniffStillDisabled($sniff::class, $stackPtr);
+
+                if ($shouldSkipSniff || $sniffIsDisabled) {
                     continue;
                 }
 
                 $this->reportActiveSniffClass($sniff);
-
-                $sniff->process($this, $stackPtr);
+                $this->disableSnifferUntil($sniff::class, $sniff->process($this, $stackPtr));
             }
         }
 
         $this->fixedCount += $this->fixer->getFixCount();
+        $this->disabledSniffers = [];
     }
 
     /**
@@ -254,6 +264,32 @@ final class File extends BaseFile
             }
         }
 
+        return true;
+    }
+
+    private function isSniffStillDisabled(string $sniffClass, int $targetStackPtr): bool
+    {
+        $disabledUntil = $this->disabledSniffers[$sniffClass] ?? 0;
+
+        if ($disabledUntil > $targetStackPtr) {
+            return true;
+        }
+
+        unset($this->disabledSniffers[$sniffClass]);
+                return false;
+            }
+
+    /**
+     * @param class-string<Sniff> $sniffClass
+     */
+    private function disableSnifferUntil(string $sniffClass, ?int $targetStackPtr = null): void
+    {
+        if ($targetStackPtr === null) {
+            return;
+        }
+
+        $this->disabledSniffers[$sniffClass] = $targetStackPtr;
+    }
         return true;
     }
 }

--- a/tests/Error/ErrorCollector/SniffFileProcessorTest.php
+++ b/tests/Error/ErrorCollector/SniffFileProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCodingStandard\Tests\Error\ErrorCollector;
 
+use PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff;
 use Symplify\EasyCodingStandard\Caching\ChangedFilesDetector;
 use Symplify\EasyCodingStandard\SniffRunner\Application\SniffFileProcessor;
 use Symplify\EasyCodingStandard\SniffRunner\ValueObject\Error\CodingStandardError;
@@ -30,6 +31,14 @@ final class SniffFileProcessorTest extends AbstractTestCase
         /** @var FileDiff[] $fileDiffs */
         $fileDiffs = $errorsAndFileDiffs['file_diffs'] ?? [];
         $this->assertCount(1, $fileDiffs);
+
+        // Make sure the strict typing declaration isn't affected when it shouldn't be.
+        foreach ($fileDiffs[0]->getAppliedCheckers() as $appliedCheck) {
+            $this->assertDoesNotMatchRegularExpression(
+                sprintf('{%s(?:\..*)?}', preg_quote(OperatorSpacingSniff::class)),
+                $appliedCheck
+            );
+        }
 
         /** @var CodingStandardError[] $codingStandardErrors */
         $codingStandardErrors = $errorsAndFileDiffs['coding_standard_errors'] ?? [];


### PR DESCRIPTION
From the related issue:

> Some PHPCS sniffer rules return a value with their `->process` method, pointing to an index in the file's token stack where the rule should turn back on. This allows them to recognize blocks of code where they do not apply.
> 
> An example of this can be seen with [`PSR12.Operators.OperatorSpacingSniff`](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/df258d47231f1ed86c59b4c51a95ec00b852f588/src/Standards/PSR12/Sniffs/Operators/OperatorSpacingSniff.php#L62). It must use this ignore functionality to avoid adding spacing to the left/right of the `=` in `declare(strict_types=1)`.
> 
> We don't currently respect any return code they provide, meaning using the PSR12 rules for ECS, PHPCS, and PHP CS Fixer together will become unresolvable.

Closes #215 