### PR TITLE
Support for multiple `skip()` usages with multiple ignore rules for the same checker

### DIFF
--- a/src/Config/ECSConfig.php
+++ b/src/Config/ECSConfig.php
@@ -25,6 +25,7 @@ use Webmozart\Assert\InvalidArgumentException;
 
 /**
  * @api
+ * @phpstan-type SkipRules list<string>|array<string|class-string<Sniff|FixerInterface>, string|list<string>|null>
  */
 final class ECSConfig extends Container
 {
@@ -49,7 +50,7 @@ final class ECSConfig extends Container
     }
 
     /**
-     * @param list<string>|array<class-string<Sniff|FixerInterface>, list<string>|null> $skips
+     * @param SkipRules $skips
      */
     public function skip(array $skips): void
     {

--- a/src/DependencyInjection/SimpleParameterProvider.php
+++ b/src/DependencyInjection/SimpleParameterProvider.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCodingStandard\DependencyInjection;
 
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\ValueObject\Option;
 use Webmozart\Assert\Assert;
 
+/**
+ * @phpstan-import-type SkipRules from ECSConfig
+ */
 final class SimpleParameterProvider
 {
     /**
@@ -16,7 +21,9 @@ final class SimpleParameterProvider
     public static function addParameter(string $key, mixed $value): void
     {
         if (is_array($value)) {
-            $mergedParameters = array_merge(self::$parameters[$key] ?? [], $value);
+            $mergedParameters = $key === Option::SKIP
+                ? self::mergeSkipRules($value)
+                : array_merge(self::$parameters[$key] ?? [], $value);
             self::$parameters[$key] = $mergedParameters;
         } else {
             self::$parameters[$key][] = $value;
@@ -65,5 +72,32 @@ final class SimpleParameterProvider
     public static function hash(): string
     {
         return sha1(serialize(self::$parameters));
+    }
+
+    /**
+     * @param SkipRules $skipRules
+     * @return SkipRules
+     */
+    private static function mergeSkipRules(array $skipRules): array
+    {
+        $rules = self::getArrayParameter(Option::SKIP);
+
+        foreach ($skipRules as $key => $value) {
+            if (is_int($key)) {
+                $rules[] = $value;
+            }
+
+            if (is_string($key)) {
+                $existingRule = $rules[$key] ?? [];
+                $additionalRule = $value ?? [];
+                $rules[$key] = array_unique(array_filter(array_merge_recursive((array)$existingRule, (array)$additionalRule)));
+
+                if ([] === $rules[$key]) {
+                    $rules[$key] = null;
+                }
+            }
+        }
+
+        return $rules;
     }
 }

--- a/src/DependencyInjection/SimpleParameterProvider.php
+++ b/src/DependencyInjection/SimpleParameterProvider.php
@@ -16,7 +16,7 @@ final class SimpleParameterProvider
     public static function addParameter(string $key, mixed $value): void
     {
         if (is_array($value)) {
-            $mergedParameters = array_merge(self::$parameters[$key] ?? [], $value);
+            $mergedParameters = array_merge_recursive(self::$parameters[$key] ?? [], $value);
             self::$parameters[$key] = $mergedParameters;
         } else {
             self::$parameters[$key][] = $value;

--- a/src/DependencyInjection/SimpleParameterProvider.php
+++ b/src/DependencyInjection/SimpleParameterProvider.php
@@ -16,7 +16,7 @@ final class SimpleParameterProvider
     public static function addParameter(string $key, mixed $value): void
     {
         if (is_array($value)) {
-            $mergedParameters = array_merge_recursive(self::$parameters[$key] ?? [], $value);
+            $mergedParameters = array_merge(self::$parameters[$key] ?? [], $value);
             self::$parameters[$key] = $mergedParameters;
         } else {
             self::$parameters[$key][] = $value;

--- a/tests/ChangedFilesDetector/ChangedFilesDetector/Source/another-configuration.php
+++ b/tests/ChangedFilesDetector/ChangedFilesDetector/Source/another-configuration.php
@@ -5,4 +5,4 @@ declare(strict_types=1);
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return ECSConfig::configure()
-    ->withSkip(['configuration-2']);
+    ->withSkip(['another-configuration']);

--- a/tests/Skipper/Skipper/Skip/SkipSkipperTest.php
+++ b/tests/Skipper/Skipper/Skip/SkipSkipperTest.php
@@ -86,5 +86,6 @@ final class SkipSkipperTest extends AbstractTestCase
         yield [SomeClassToSkip::class, __DIR__ . '/Fixture/AlwaysSkippedPath', true];
         yield [SomeClassToSkip::class, __DIR__ . '/Fixture/someDirectory', false];
         yield [SomeClassToSkip::class, __DIR__ . '/Fixture/someDirectory/someFile.php', true];
+        yield [AnotherClassToSkip::class, __DIR__ . '/Fixture', true];
     }
 }

--- a/tests/Skipper/Skipper/Skip/SkipSkipperTest.php
+++ b/tests/Skipper/Skipper/Skip/SkipSkipperTest.php
@@ -6,6 +6,7 @@ namespace Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip;
 
 use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symplify\EasyCodingStandard\Skipper\Skipper\Skipper;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractTestCase;
 use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\AnotherClassToSkip;
@@ -14,6 +15,7 @@ use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\SomeClassToSki
 
 final class SkipSkipperTest extends AbstractTestCase
 {
+    #[RunInSeparateProcess]
     #[DataProvider('provideCheckerAndFile')]
     #[DataProvider('provideCodeAndFile')]
     #[DataProvider('provideMessageAndFile')]
@@ -71,6 +73,7 @@ final class SkipSkipperTest extends AbstractTestCase
         yield ['anything', __DIR__ . '/Fixture/PathSkippedWithMask/another_file.txt', true];
     }
 
+    #[RunInSeparateProcess]
     #[DataProvider('provideCheckerAndFileForRecursivelyMergedConfig')]
     public function testCheckerSkipRulesAreMergedRecursively(string $element, string $filePath, bool $expectedSkip): void
     {

--- a/tests/Skipper/Skipper/Skip/config/config_with_import.php
+++ b/tests/Skipper/Skipper/Skip/config/config_with_import.php
@@ -6,10 +6,10 @@ use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\AnotherClassToSkip;
 use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\SomeClassToSkip;
 
-return static function (ECSConfig $config): void {
-    $config->import(__DIR__.'/imported_config.php');
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->import(__DIR__.'/imported_config.php');
 
-    $config->skip([
+    $ecsConfig->skip([
         SomeClassToSkip::class => 'Fixture/AlwaysSkippedPath',
         AnotherClassToSkip::class => null,
     ]);

--- a/tests/Skipper/Skipper/Skip/config/config_with_import.php
+++ b/tests/Skipper/Skipper/Skip/config/config_with_import.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\AnotherClassToSkip;
 use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\SomeClassToSkip;
 
 return static function (ECSConfig $config): void {
     $config->import(__DIR__.'/imported_config.php');
 
     $config->skip([
-        SomeClassToSkip::class => ['Fixture/AlwaysSkippedPath'],
+        SomeClassToSkip::class => 'Fixture/AlwaysSkippedPath',
+        AnotherClassToSkip::class => null,
     ]);
 };

--- a/tests/Skipper/Skipper/Skip/config/config_with_import.php
+++ b/tests/Skipper/Skipper/Skip/config/config_with_import.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\SomeClassToSkip;
+
+return static function (ECSConfig $config): void {
+    $config->import(__DIR__.'/imported_config.php');
+
+    $config->skip([
+        SomeClassToSkip::class => ['Fixture/AlwaysSkippedPath'],
+    ]);
+};

--- a/tests/Skipper/Skipper/Skip/config/imported_config.php
+++ b/tests/Skipper/Skipper/Skip/config/imported_config.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\SomeClassToSkip;
+
+return static function (ECSConfig $config): void {
+    $config->skip([
+        SomeClassToSkip::class => ['Fixture/someDirectory/someFile.php'],
+    ]);
+};

--- a/tests/Skipper/Skipper/Skip/config/imported_config.php
+++ b/tests/Skipper/Skipper/Skip/config/imported_config.php
@@ -6,8 +6,8 @@ use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\AnotherClassToSkip;
 use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\SomeClassToSkip;
 
-return static function (ECSConfig $config): void {
-    $config->skip([
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->skip([
         SomeClassToSkip::class => ['Fixture/someDirectory/someFile.php'],
         AnotherClassToSkip::class => null,
     ]);

--- a/tests/Skipper/Skipper/Skip/config/imported_config.php
+++ b/tests/Skipper/Skipper/Skip/config/imported_config.php
@@ -3,10 +3,12 @@
 declare(strict_types=1);
 
 use Symplify\EasyCodingStandard\Config\ECSConfig;
+use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\AnotherClassToSkip;
 use Symplify\EasyCodingStandard\Tests\Skipper\Skipper\Skip\Source\SomeClassToSkip;
 
 return static function (ECSConfig $config): void {
     $config->skip([
         SomeClassToSkip::class => ['Fixture/someDirectory/someFile.php'],
+        AnotherClassToSkip::class => null,
     ]);
 };


### PR DESCRIPTION
Imagine you have `$config->skip([SomeRule::class => __DIR__.'/foo'])` in main `ecs.php` _and_ `$config->skip([SomeRule::class => __DIR__.'/bar'])` in some ruleset included in the main config. Currently the result of skip option is the last `skip()` call, because arrays are not merged recursively. This caused some issue in our codebase where we had ignore rules for legacy part of the app in the custom ruleset, and one developer added new ignore rule for `DeclareStrictTypesFixer` in the main config, effectively overriding previous ignore rules. I've tested it locally and using `array_merge_recursive()` solves the problem - the result ignore rules set contains entries from all `skip()` calls.

PS. I did not see tests for `SimpleParameterProvider`, that's why I did not add new ones. Creating PR for discussion, let me know if the fix is acceptable.