### PR TITLE
New Feature: Add .editorconfig Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,28 @@ vendor/bin/ecs list-checkers --output-format json
 
 <br>
 
+### Can I Use My [`.editorconfig`](https://editorconfig.org/)?
+
+Mostly! By using `withEditorConfig()`, ECS will automatically discover
+the `.editorconfig` file in the project's root directory. It will use any
+rules under `[*]` or `[*.php]` (the latter taking priority) and respect the
+settings for:
+
+-   `indent_style`
+-   `end_of_line`
+-   `max_line_length`
+-   `trim_trailing_whitespace`
+-   `insert_final_newline`
+-   [`quote_type`](https://github.com/jednano/codepainter#quote_type-single-double-auto)
+    -   Only `single` and `auto` are respected.
+    -   Warning: this is a proposed field, but not fully standard.
+
+These settings will take precedence over similar rules configured through sets
+like PSR12, to avoid conflicting with other tooling using your `.editorconfig`.
+
+Unfortunately, not all settings are currently respected, but PRs are always
+welcome!
+
 ## How to Migrate from another coding standard tool?
 
 Do you use another tool and want to migrate? It's pretty straightforward - here is "how to":

--- a/ecs.php
+++ b/ecs.php
@@ -1,10 +1,12 @@
 <?php
 
 declare(strict_types=1);
+
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return ECSConfig::configure()
+    ->withEditorConfig()
     ->withPaths([__DIR__ . '/config', __DIR__ . '/src', __DIR__ . '/tests'])
     ->withRules([LineLengthFixer::class])
     ->withRootFiles()

--- a/src/Configuration/EditorConfig/EditorConfig.php
+++ b/src/Configuration/EditorConfig/EditorConfig.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Configuration\EditorConfig;
+
+/**
+ * @see https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+ */
+class EditorConfig
+{
+    public function __construct(
+        public readonly ?IndentStyle $indentStyle,
+        public readonly ?EndOfLine $endOfLine,
+        public readonly ?bool $trimTrailingWhitespace,
+        public readonly ?bool $insertFinalNewline,
+        public readonly ?int $maxLineLength,
+        public readonly ?QuoteType $quoteType
+    ) {
+    }
+}

--- a/src/Configuration/EditorConfig/EditorConfigFactory.php
+++ b/src/Configuration/EditorConfig/EditorConfigFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Configuration\EditorConfig;
+
+use Exception;
+
+class EditorConfigFactory
+{
+    public function load(): EditorConfig
+    {
+        // By default, composer executes scripts from within the project root.
+        $projectRoot = getcwd();
+        $editorConfigPath = $projectRoot . '/.editorconfig';
+
+        if (! file_exists($editorConfigPath)) {
+            throw new Exception('No .editorconfig found.');
+        }
+
+        $configFileContent = file_get_contents($editorConfigPath);
+
+        if ($configFileContent === false) {
+            throw new Exception('Unable to load .editorconfig.');
+        }
+
+        return $this->parse($configFileContent);
+    }
+
+    public function parse(string $editorConfigFileContents): EditorConfig
+    {
+        $fullConfig = parse_ini_string($editorConfigFileContents, true, INI_SCANNER_TYPED);
+
+        if ($fullConfig === false) {
+            throw new Exception('Unable to parse .editorconfig.');
+        }
+
+        $config = [...$fullConfig['*'] ?? [], ...$fullConfig['*.php'] ?? []];
+
+        // Just letting "validation" happen with PHP's type hints.
+        return new EditorConfig(
+            indentStyle: $this->field($config, 'indent_style', IndentStyle::tryFrom(...)),
+            endOfLine: $this->field($config, 'end_of_line', EndOfLine::tryFrom(...)),
+            trimTrailingWhitespace: $this->field($config, 'trim_trailing_whitespace', $this->id(...)),
+            insertFinalNewline: $this->field($config, 'insert_final_newline', $this->id(...)),
+            maxLineLength: $this->field($config, 'max_line_length', $this->id(...)),
+            quoteType: $this->field($config, 'quote_type', QuoteType::tryFrom(...)),
+        );
+    }
+
+    /**
+     * @template From
+     * @template To
+     * @param mixed[] $config
+     * @param callable(From): To $transform
+     * @return To|null
+     */
+    private function field(array $config, string $field, callable $transform): mixed
+    {
+        if (! isset($config[$field])) {
+            return null;
+        }
+
+        return $transform($config[$field]);
+    }
+
+    /**
+     * @template T
+     * @param T $value
+     * @return T
+     */
+    private function id(mixed $value): mixed
+    {
+        return $value;
+    }
+}

--- a/src/Configuration/EditorConfig/EndOfLine.php
+++ b/src/Configuration/EditorConfig/EndOfLine.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Configuration\EditorConfig;
+
+enum EndOfLine: string
+{
+    case Posix = 'lf';
+    case Legacy = 'cr';
+    case Windows = 'crlf';
+}

--- a/src/Configuration/EditorConfig/IndentStyle.php
+++ b/src/Configuration/EditorConfig/IndentStyle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Configuration\EditorConfig;
+
+enum IndentStyle: string
+{
+    case Space = 'space';
+    case Tab = 'tab';
+}

--- a/src/Configuration/EditorConfig/QuoteType.php
+++ b/src/Configuration/EditorConfig/QuoteType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Configuration\EditorConfig;
+
+/**
+ * @see https://github.com/jednano/codepainter#quote_type-single-double-auto
+ */
+enum QuoteType: string
+{
+    case Single = 'single';
+    case Double = 'double';
+    case Auto = 'auto';
+}

--- a/src/DependencyInjection/CompilerPass/ConflictingCheckersCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/ConflictingCheckersCompilerPass.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Symplify\EasyCodingStandard\DependencyInjection\CompilerPass;
 
 use Illuminate\Container\Container;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNewlineSniff as GenericEndFileNewlineSniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNoNewlineSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseConstantSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\UpperCaseConstantSniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowSpaceIndentSniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowTabIndentSniff;
 use PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\FileHeaderSniff;
+use PHP_CodeSniffer\Standards\PSR2\Sniffs\Files\EndFileNewlineSniff;
 use PhpCsFixer\Fixer\Casing\ConstantCaseFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer;
@@ -32,6 +37,9 @@ final class ConflictingCheckersCompilerPass
         ['SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff', DeclareEqualNormalizeFixer::class],
         ['SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff', BlankLineAfterOpeningTagFixer::class],
         [FileHeaderSniff::class, NoBlankLinesAfterPhpdocFixer::class],
+        [EndFileNewlineSniff::class, EndFileNoNewlineSniff::class],
+        [GenericEndFileNewlineSniff::class, EndFileNoNewlineSniff::class],
+        [DisallowTabIndentSniff::class, DisallowSpaceIndentSniff::class],
     ];
 
     public function process(Container $container): void

--- a/src/DependencyInjection/CompilerPass/RemoveMutualCheckersCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/RemoveMutualCheckersCompilerPass.php
@@ -8,7 +8,9 @@ use Illuminate\Container\Container;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowLongArraySyntaxSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Arrays\DisallowShortArraySyntaxSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\EndFileNewlineSniff as GenericEndFileNewlineSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineEndingsSniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\DisallowMultipleStatementsSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseConstantSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\LowerCaseKeywordSniff;
@@ -52,7 +54,9 @@ use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
 use PhpCsFixer\Fixer\Whitespace\IndentationTypeFixer;
 use PhpCsFixer\Fixer\Whitespace\LineEndingFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
+use PhpCsFixer\Fixer\Whitespace\NoTrailingWhitespaceFixer;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 
 final class RemoveMutualCheckersCompilerPass
 {
@@ -62,6 +66,7 @@ final class RemoveMutualCheckersCompilerPass
      * @var string[][]
      */
     private const DUPLICATED_CHECKER_GROUPS = [
+        [IndentationTypeFixer::class, ScopeIndentSniff::class],
         [IndentationTypeFixer::class, DisallowTabIndentSniff::class],
         [IndentationTypeFixer::class, DisallowSpaceIndentSniff::class],
         [StrictComparisonFixer::class, 'SlevomatCodingStandard\Sniffs\Operators\DisallowEqualOperatorsSniff'],
@@ -89,6 +94,7 @@ final class RemoveMutualCheckersCompilerPass
             'SlevomatCodingStandard\Sniffs\Commenting\ForbiddenAnnotationsSniff',
         ],
         [NoExtraBlankLinesFixer::class, SuperfluousWhitespaceSniff::class],
+        [NoTrailingWhitespaceFixer::class, SuperfluousWhitespaceSniff::class],
         [IncludeFixer::class, LanguageConstructSpacingSniff::class],
         [
             AssignmentInConditionSniff::class,
@@ -104,11 +110,14 @@ final class RemoveMutualCheckersCompilerPass
         [ConstantCaseFixer::class, LowerCaseConstantSniff::class],
         [LowercaseKeywordsFixer::class, LowerCaseKeywordSniff::class],
         [SingleBlankLineAtEofFixer::class, EndFileNewlineSniff::class],
+        [SingleBlankLineAtEofFixer::class, GenericEndFileNewlineSniff::class],
+        [EndFileNewlineSniff::class, GenericEndFileNewlineSniff::class],
         [BracesFixer::class, ScopeIndentSniff::class],
         [BracesFixer::class, ScopeClosingBraceSniff::class],
         [ClassDefinitionFixer::class, ClassDeclarationSniff::class],
         [NoClosingTagFixer::class, ClosingTagSniff::class],
         [SingleClassElementPerStatementFixer::class, PropertyDeclarationSniff::class],
+        [LineLengthFixer::class, LineLengthSniff::class],
     ];
 
     public function process(Container $container): void

--- a/src/SniffRunner/ValueObject/File.php
+++ b/src/SniffRunner/ValueObject/File.php
@@ -66,7 +66,7 @@ final class File extends BaseFile
         $this->eolChar = Common::detectLineEndings($content);
 
         // compat
-        if (! defined('PHP_CODESNIFFER_CBF')) {
+        if (!defined('PHP_CODESNIFFER_CBF')) {
             define('PHP_CODESNIFFER_CBF', false);
         }
 
@@ -87,12 +87,12 @@ final class File extends BaseFile
         $this->fixer->startFile($this);
 
         $currentFilePath = $this->filePath;
-        if (! is_string($currentFilePath)) {
+        if (!is_string($currentFilePath)) {
             throw new ShouldNotHappenException();
         }
 
         foreach ($this->tokens as $stackPtr => $token) {
-            if (! isset($this->tokenListeners[$token['code']])) {
+            if (!isset($this->tokenListeners[$token['code']])) {
                 continue;
             }
 
@@ -123,7 +123,7 @@ final class File extends BaseFile
         $fullyQualifiedCode = $this->resolveFullyQualifiedCode($code);
         $this->sniffMetadataCollector->addAppliedSniff($fullyQualifiedCode);
 
-        return ! $this->shouldSkipError($error, $code, $data);
+        return !$this->shouldSkipError($error, $code, $data);
     }
 
     /**
@@ -185,7 +185,7 @@ final class File extends BaseFile
         $isFixable = false
     ): bool {
         // skip warnings
-        if (! $isError) {
+        if (!$isError) {
             return false;
         }
 
@@ -215,7 +215,7 @@ final class File extends BaseFile
         // used in other places later
         $this->activeSniffClass = $sniff::class;
 
-        if (! $this->easyCodingStandardStyle->isDebug()) {
+        if (!$this->easyCodingStandardStyle->isDebug()) {
             return;
         }
 
@@ -243,7 +243,7 @@ final class File extends BaseFile
     {
         $fullyQualifiedCode = $this->resolveFullyQualifiedCode($code);
 
-        if (! is_string($this->filePath)) {
+        if (!is_string($this->filePath)) {
             throw new ShouldNotHappenException();
         }
 
@@ -276,8 +276,8 @@ final class File extends BaseFile
         }
 
         unset($this->disabledSniffers[$sniffClass]);
-                return false;
-            }
+        return false;
+    }
 
     /**
      * @param class-string<Sniff> $sniffClass
@@ -289,7 +289,5 @@ final class File extends BaseFile
         }
 
         $this->disabledSniffers[$sniffClass] = $targetStackPtr;
-    }
-        return true;
     }
 }

--- a/src/SniffRunner/ValueObject/File.php
+++ b/src/SniffRunner/ValueObject/File.php
@@ -66,7 +66,7 @@ final class File extends BaseFile
         $this->eolChar = Common::detectLineEndings($content);
 
         // compat
-        if (!defined('PHP_CODESNIFFER_CBF')) {
+        if (! defined('PHP_CODESNIFFER_CBF')) {
             define('PHP_CODESNIFFER_CBF', false);
         }
 
@@ -87,12 +87,12 @@ final class File extends BaseFile
         $this->fixer->startFile($this);
 
         $currentFilePath = $this->filePath;
-        if (!is_string($currentFilePath)) {
+        if (! is_string($currentFilePath)) {
             throw new ShouldNotHappenException();
         }
 
         foreach ($this->tokens as $stackPtr => $token) {
-            if (!isset($this->tokenListeners[$token['code']])) {
+            if (! isset($this->tokenListeners[$token['code']])) {
                 continue;
             }
 
@@ -123,7 +123,7 @@ final class File extends BaseFile
         $fullyQualifiedCode = $this->resolveFullyQualifiedCode($code);
         $this->sniffMetadataCollector->addAppliedSniff($fullyQualifiedCode);
 
-        return !$this->shouldSkipError($error, $code, $data);
+        return ! $this->shouldSkipError($error, $code, $data);
     }
 
     /**
@@ -185,7 +185,7 @@ final class File extends BaseFile
         $isFixable = false
     ): bool {
         // skip warnings
-        if (!$isError) {
+        if (! $isError) {
             return false;
         }
 
@@ -215,7 +215,7 @@ final class File extends BaseFile
         // used in other places later
         $this->activeSniffClass = $sniff::class;
 
-        if (!$this->easyCodingStandardStyle->isDebug()) {
+        if (! $this->easyCodingStandardStyle->isDebug()) {
             return;
         }
 
@@ -243,7 +243,7 @@ final class File extends BaseFile
     {
         $fullyQualifiedCode = $this->resolveFullyQualifiedCode($code);
 
-        if (!is_string($this->filePath)) {
+        if (! is_string($this->filePath)) {
             throw new ShouldNotHappenException();
         }
 

--- a/src/SniffRunner/ValueObject/File.php
+++ b/src/SniffRunner/ValueObject/File.php
@@ -38,6 +38,13 @@ final class File extends BaseFile
     private ?string $filePath = null;
 
     /**
+     * @var array<class-string<Sniff>, int> A map of which sniffers have
+     *     requested themselves to be disabled, pointing to the index in
+     *     the files token stack that they are to be re-enabled.
+     */
+    private array $disabledSniffers = [];
+
+    /**
      * @var array<class-string<Sniff>>
      */
     private array $reportSniffClassesWarnings = [];
@@ -90,17 +97,20 @@ final class File extends BaseFile
             }
 
             foreach ($this->tokenListeners[$token['code']] as $sniff) {
-                if ($this->skipper->shouldSkipElementAndFilePath($sniff, $currentFilePath)) {
+                $shouldSkipSniff = $this->skipper->shouldSkipElementAndFilePath($sniff, $currentFilePath);
+                $sniffIsDisabled = $this->isSniffStillDisabled($sniff::class, $stackPtr);
+
+                if ($shouldSkipSniff || $sniffIsDisabled) {
                     continue;
                 }
 
                 $this->reportActiveSniffClass($sniff);
-
-                $sniff->process($this, $stackPtr);
+                $this->disableSnifferUntil($sniff::class, $sniff->process($this, $stackPtr));
             }
         }
 
         $this->fixedCount += $this->fixer->getFixCount();
+        $this->disabledSniffers = [];
     }
 
     /**
@@ -254,6 +264,32 @@ final class File extends BaseFile
             }
         }
 
+        return true;
+    }
+
+    private function isSniffStillDisabled(string $sniffClass, int $targetStackPtr): bool
+    {
+        $disabledUntil = $this->disabledSniffers[$sniffClass] ?? 0;
+
+        if ($disabledUntil > $targetStackPtr) {
+            return true;
+        }
+
+        unset($this->disabledSniffers[$sniffClass]);
+                return false;
+            }
+
+    /**
+     * @param class-string<Sniff> $sniffClass
+     */
+    private function disableSnifferUntil(string $sniffClass, ?int $targetStackPtr = null): void
+    {
+        if ($targetStackPtr === null) {
+            return;
+        }
+
+        $this->disabledSniffers[$sniffClass] = $targetStackPtr;
+    }
         return true;
     }
 }

--- a/tests/Configuration/EditorConfig/EditorConfigFactoryTest.php
+++ b/tests/Configuration/EditorConfig/EditorConfigFactoryTest.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Tests\Configuration\EditorConfig;
+
+use Exception;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Symplify\EasyCodingStandard\Configuration\EditorConfig\EditorConfig;
+use Symplify\EasyCodingStandard\Configuration\EditorConfig\EditorConfigFactory;
+use Symplify\EasyCodingStandard\Configuration\EditorConfig\EndOfLine;
+use Symplify\EasyCodingStandard\Configuration\EditorConfig\IndentStyle;
+use Symplify\EasyCodingStandard\Configuration\EditorConfig\QuoteType;
+use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractTestCase;
+
+final class EditorConfigFactoryTest extends AbstractTestCase
+{
+    public function testLoadingFromProjectRoot(): void
+    {
+        // Depends on the ECS project itself using an `.editorconfig`.
+        $editorConfigFactory = new EditorConfigFactory();
+        $editorConfig = $editorConfigFactory->load();
+
+        $this->assertEquals($editorConfig, new EditorConfig(
+            indentStyle: IndentStyle::Space,
+            endOfLine: EndOfLine::Posix,
+            insertFinalNewline: true,
+            trimTrailingWhitespace: true,
+            maxLineLength: null,
+            quoteType: null
+        ));
+    }
+
+    #[RunInSeparateProcess]
+    public function testLoadingBadFilepath(): void
+    {
+        chdir(__DIR__);
+
+        $this->expectException(Exception::class);
+
+        $editorConfigFactory = new EditorConfigFactory();
+        $editorConfigFactory->load();
+    }
+
+    public function testParsingInvalidIniFile(): void
+    {
+        $this->expectException(Exception::class);
+
+        $editorConfigFactory = new EditorConfigFactory();
+        @$editorConfigFactory->parse(<<<INI
+            fleeb!
+            INI
+        );
+    }
+
+    public function testLoadsExpectedSections(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                indent_style = space
+                max_line_length = 100
+
+                [*.php]
+                indent_style = tab
+                end_of_line = lf
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: IndentStyle::Tab,
+                endOfLine: EndOfLine::Posix,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: 100,
+                quoteType: null
+            ),
+        );
+    }
+
+    public function testEmpty(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(''),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testIndentStyleSpaces(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                indent_style = space
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: IndentStyle::Space,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testIndentStyleTabs(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                indent_style = tab
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: IndentStyle::Tab,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testEndOfLinePosix(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                end_of_line = lf
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: EndOfLine::Posix,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testEndOfLineLegacy(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                end_of_line = cr
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: EndOfLine::Legacy,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testEndOfLineWindows(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                end_of_line = crlf
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: EndOfLine::Windows,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testTrimTrailingWhitespaceEnabled(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                trim_trailing_whitespace = true
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: true,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testTrimTrailingWhitespaceDisabled(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                trim_trailing_whitespace = false
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: false,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testInsertFinalNewlineEnabled(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                insert_final_newline = true
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: true,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testInsertFinalNewlineDisabled(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                insert_final_newline = false
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: false,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: null
+            )
+        );
+    }
+
+    public function testMaxLineLength(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                max_line_length = 63
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: 63,
+                quoteType: null
+            )
+        );
+    }
+
+    public function quoteTypeAuto(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                quote_type = auto
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: QuoteType::Auto
+            )
+        );
+    }
+
+    public function quoteTypeSingle(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                quote_type = single
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: QuoteType::Single
+            )
+        );
+    }
+
+    public function quoteTypeDouble(): void
+    {
+        $this->assertEquals(
+            (new EditorConfigFactory())->parse(
+                <<<INI
+                [*]
+                quote_type = double
+                INI
+            ),
+            new EditorConfig(
+                indentStyle: null,
+                endOfLine: null,
+                insertFinalNewline: null,
+                trimTrailingWhitespace: null,
+                maxLineLength: null,
+                quoteType: QuoteType::Double
+            )
+        );
+    }
+}

--- a/tests/Error/ErrorCollector/SniffFileProcessorTest.php
+++ b/tests/Error/ErrorCollector/SniffFileProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCodingStandard\Tests\Error\ErrorCollector;
 
+use PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff;
 use Symplify\EasyCodingStandard\Caching\ChangedFilesDetector;
 use Symplify\EasyCodingStandard\SniffRunner\Application\SniffFileProcessor;
 use Symplify\EasyCodingStandard\SniffRunner\ValueObject\Error\CodingStandardError;
@@ -30,6 +31,14 @@ final class SniffFileProcessorTest extends AbstractTestCase
         /** @var FileDiff[] $fileDiffs */
         $fileDiffs = $errorsAndFileDiffs['file_diffs'] ?? [];
         $this->assertCount(1, $fileDiffs);
+
+        // Make sure the strict typing declaration isn't affected when it shouldn't be.
+        foreach ($fileDiffs[0]->getAppliedCheckers() as $appliedCheck) {
+            $this->assertDoesNotMatchRegularExpression(
+                sprintf('{%s(?:\..*)?}', preg_quote(OperatorSpacingSniff::class)),
+                $appliedCheck
+            );
+        }
 
         /** @var CodingStandardError[] $codingStandardErrors */
         $codingStandardErrors = $errorsAndFileDiffs['coding_standard_errors'] ?? [];


### PR DESCRIPTION
The approach I've gone for puts `.editorconfig` settings above those settings in the `ecs.php` config itself, to prioritize convenience for those people using pre-built sets. As many setttings as I could easily implement have been supported, including one proposed (but not standardized) setting I like to use.

As mentioned in the related ticket, I've used a similar approach [as Prettier does](https://github.com/prettier/prettier/blob/917faa3a11addf73ba8168d0afa3dbb1c85a5958/src/config/editorconfig/editorconfig-to-prettier.js#L14), only pulling configuration settings from `[*]` and `[*.php]` at the root-level `.editorconfig` (no recursive traversal to `root`), since we don't have immediate access to a high quality EditorConfig library and don't want to maintain anything that complicated.

The changes made here should also be backwards-compatible for a minor version release; opt-in for support is required for the new feature, and all other changes make the checker *more* permissive. But please do check my work, especially in regard to the changed conflicting / duplicate checker entries.

This commit includes tests, documentation, and dogfooding.

Tests only currently cover the parsing of `.editorconfig`, but do not test how all permutations affect configuration. Doing so would require advanced alias mocks of the `EditorConfigFactory` and it's `load` method, which I wasn't able to get working in an initial attempt. That, or a refactor of `ECSConfigBuilder` to allow injecting the factory, but I didn't want to mess with  any of the exposed public API.

Closes #217

----

Thank you for your time! 😄 