### PR TITLE
Allow compatibility with sebastian/diff version 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "friendsofphp/php-cs-fixer": "^3.64",
         "illuminate/container": "^10.48",
         "nette/utils": "^4.0",
-        "sebastian/diff": "^5.1",
+        "sebastian/diff": "^5.1 || ^6.0",
         "squizlabs/php_codesniffer": "^3.10.3",
         "symfony/console": "^6.4",
         "symfony/finder": "^7.1",


### PR DESCRIPTION
I wanted to install `symplify/easy-coding-standard:dev-main` to see if all PHP 8.4 deprecation warnings have been fixed already, but was unable to.

```
composer require symplify/easy-coding-standard:dev-main --dev         
./composer.json has been updated
Running composer update symplify/easy-coding-standard
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires symplify/easy-coding-standard dev-main -> satisfiable by symplify/easy-coding-standard[dev-main].
    - symplify/easy-coding-standard dev-main requires sebastian/diff ^5.1 -> found sebastian/diff[5.1.0, 5.1.1] but the package is fixed to 6.0.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

It turns out that PHPUnit 11 depends on `sebastian/diff:6.0.2` and no longer allows `5.1`:

```
composer require sebastian/diff:^5.1 --dev
The "5.1" constraint for "sebastian/diff" appears too strict and will likely not match what you want. See https://getcomposer.org/constraints
./composer.json has been updated
Running composer update sebastian/diff
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires sebastian/diff 5.1 (exact version match: 5.1, 5.1.0 or 5.1.0.0), found sebastian/diff[5.1.0] but these were not loaded, likely because it conflicts with another require.
  Problem 2
    - phpunit/phpunit is locked to version 11.3.5 and an update of this package was not requested.
    - phpunit/phpunit 11.3.5 requires sebastian/diff ^6.0.2 -> found sebastian/diff[6.0.2] but it conflicts with your root composer.json require (5.1).
  Problem 3
    - symplify/coding-standard is locked to version 12.2.3 and an update of this package was not requested.
    - friendsofphp/php-cs-fixer v3.62.0 requires sebastian/diff ^4.0 || ^5.0 || ^6.0 -> found sebastian/diff[4.0.0, ..., 4.0.6, 5.0.0, ..., 5.1.1, 6.0.0, 6.0.1, 6.0.2] but these were not loaded, likely because it conflicts with another require.
    - symplify/coding-standard 12.2.3 requires friendsofphp/php-cs-fixer ^3.59 -> satisfiable by friendsofphp/php-cs-fixer[v3.62.0].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```
