### PR TITLE
Fix Symfony\Component\String\UnicodeString not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,8 +85,7 @@
         "symfony/polyfill-intl-normalizer": "*",
         "symfony/event-dispatcher": "7.*",
         "symfony/process": "7.*",
-        "symfony/stopwatch": "7.*",
-        "symfony/string": "7.*"
+        "symfony/stopwatch": "7.*"
     },
     "extra": {
         "patches": {


### PR DESCRIPTION
Same issue with on rector-src https://github.com/rectorphp/rector-src/actions/runs/16699373232/job/47268005468

```
PHP Fatal error:  Uncaught Error: Class "Symfony\Component\String\UnicodeString" not found in /home/runner/work/rector-src/rector-src/vendor/symfony/console/Helper/Helper.php:92
Stack trace:
```

this removal of symfony/string "replace" to avoid error on due to latest `myclabs/deep-copy:1.13.4`