### PR TITLE
Fix a deprecated implicit nullable parameter in PHP 8.4

### DIFF
--- a/tests/Console/Output/GitlabOutputFormatterTest.php
+++ b/tests/Console/Output/GitlabOutputFormatterTest.php
@@ -154,7 +154,7 @@ final class GitlabOutputFormatterTest extends AbstractTestCase
     /**
      * @return array{CodingStandardError[], FileDiff[]}
      */
-    private function getMockedIssues(string $filePathForChanges = null): array
+    private function getMockedIssues(?string $filePathForChanges = null): array
     {
         $filePathForOriginal = $this->path('/Source/RandomFile.php');
 


### PR DESCRIPTION
Running `composer test` in PHP 8.4 gives a deprecated 
```
Deprecated: Symplify\EasyCodingStandard\Tests\Console\Output\GitlabOutputFormatterTest::getMockedIssues(): Implicitly marking parameter $filePathForChanges as nullable is deprecated, the explicit nullable type must be used instead in ~/easy-coding-standard/tests/Console/Output/GitlabOutputFormatterTest.php on line 157
```

This PR corrects that point. 

I used `chore:` in log commit ; feel free to tell me to change if needed.