### PR TITLE
fix: Let intl polyfill in dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,9 +80,7 @@
         "fix-cs": "bin/ecs check --fix --ansi"
     },
     "replace": {
-        "symfony/polyfill-intl-grapheme": "*",
         "symfony/polyfill-ctype": "*",
-        "symfony/polyfill-intl-normalizer": "*",
         "symfony/event-dispatcher": "7.*",
         "symfony/process": "7.*",
         "symfony/stopwatch": "7.*"


### PR DESCRIPTION
Environment without PHP Intl extension enabled
gave a Fatal Error when using ECS.

Refs: #293