### PR TITLE
Allow squizlabs/php_codesniffer ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/container": "^12.21",
         "nette/utils": "^4.0.7",
         "sebastian/diff": "^6.0.2",
-        "squizlabs/php_codesniffer": "^3.13.4",
+        "squizlabs/php_codesniffer": "^3.13.4 || ^4.0",
         "symfony/console": "^6.4.24",
         "symfony/finder": "^7.3.0",
         "symplify/coding-standard": "^12.4.3",


### PR DESCRIPTION
[PHPCSStandards/PHP_CodeSniffer@4.0.0 (release)](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/4.0.0) has been released.