### PR TITLE
Fix URL for creating issue to report problem

### DIFF
--- a/src/Parallel/WorkerRunner.php
+++ b/src/Parallel/WorkerRunner.php
@@ -74,7 +74,7 @@ final readonly class WorkerRunner
                     ++$systemErrorsCount;
 
                     $errorMessage = sprintf('System error: "%s"', $throwable->getMessage());
-                    $errorMessage .= 'Run ECS with "--debug" option and post the report here: https://github.com/symplify/symplify/issues/new';
+                    $errorMessage .= 'Run ECS with "--debug" option and post the report here: https://github.com/easy-coding-standard/easy-coding-standard/issues/new';
                     $systemErrors[] = new SystemError($throwable->getLine(), $errorMessage, $filePath);
                 }
             }


### PR DESCRIPTION
The old URL is redirected to the [archived monorepo](https://github.com/deprecated-packages/symplify), so we [cannot create issues there](https://github.com/deprecated-packages/symplify/issues/new).