### PR TITLE
Reconfigure OrderedImportsFixer rule settings to sort class, function, const

### DIFF
--- a/config/set/clean-code.php
+++ b/config/set/clean-code.php
@@ -19,9 +19,11 @@ return ECSConfig::configure()
     ->withRules([
         ParamReturnAndVarTagMalformsFixer::class,
         NoUnusedImportsFixer::class,
-        OrderedImportsFixer::class,
         NoEmptyStatementFixer::class,
         ProtectedToPrivateFixer::class,
         NoUnneededControlParenthesesFixer::class,
         NoUnneededCurlyBracesFixer::class,
+    ])
+    ->withConfiguredRule(OrderedImportsFixer::class, [
+        'imports_order' => ['class', 'function', 'const'],
     ]);


### PR DESCRIPTION
Avoid mix between sort class, function, const, see example of latest update without configure it.

https://github.com/rectorphp/rector-src/commit/e040c5e3ea0f7b42510f8afab967591abd6e6b77

which mix, which with configure it, it will be append after sorted class.

Reference:

- https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/5801